### PR TITLE
feat: Add two-tier state management (RequestState/SessionState)

### DIFF
--- a/lobster/core/schemas/__init__.py
+++ b/lobster/core/schemas/__init__.py
@@ -23,6 +23,17 @@ from .clinical_schema import (
     is_non_responder,
 )
 
+# Two-Tier State Management (BioAgents-inspired)
+from .state import (
+    StepTiming,
+    RequestState,
+    ResearchProgress,
+    SessionState,
+    StateManager,
+    create_request_state,
+    create_session_state,
+)
+
 __all__ = [
     "DownloadQueueEntry",
     "DownloadStatus",
@@ -42,4 +53,12 @@ __all__ = [
     "classify_response_group",
     "is_responder",
     "is_non_responder",
+    # Two-Tier State Management exports
+    "StepTiming",
+    "RequestState",
+    "ResearchProgress",
+    "SessionState",
+    "StateManager",
+    "create_request_state",
+    "create_session_state",
 ]

--- a/lobster/core/schemas/state.py
+++ b/lobster/core/schemas/state.py
@@ -1,0 +1,661 @@
+"""
+Two-Tier State Management for Lobster AI.
+
+Inspired by BioAgents' state architecture, this module implements:
+- Tier 1: RequestState - Transient, per-request, discarded after processing
+- Tier 2: SessionState - Persistent, per-session, saved to `.session_state.json`
+
+The StateManager class orchestrates both tiers, handling lifecycle and persistence.
+
+Example Usage:
+    state_manager = StateManager(workspace_path)
+
+    # Start request
+    request_state = state_manager.start_request(request_id="req-123")
+    session_state = state_manager.load_session(session_id="sess-456")
+
+    # During processing
+    request_state.start_step("analysis")
+    # ... agent work ...
+    request_state.end_step("analysis")
+    session_state.add_insight("Found 100 differentially expressed genes")
+
+    # End request
+    state_manager.save_session(session_state)
+    summary = state_manager.end_request()  # request_state is discarded
+"""
+
+import json
+import logging
+import threading
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# TIER 1: REQUEST STATE (Transient)
+# =============================================================================
+
+
+class StepTiming(BaseModel):
+    """
+    Timing information for a single execution step.
+
+    Used to track duration of individual operations within a request
+    (e.g., "planning", "analysis", "export").
+    """
+
+    name: str = Field(description="Step identifier (e.g., 'planning', 'clustering')")
+    start: datetime = Field(description="UTC timestamp when step started")
+    end: Optional[datetime] = Field(default=None, description="UTC timestamp when step ended")
+    duration_ms: Optional[int] = Field(
+        default=None, description="Duration in milliseconds (computed on end)"
+    )
+
+    def complete(self) -> None:
+        """Mark step as complete and compute duration."""
+        self.end = datetime.utcnow()
+        self.duration_ms = int((self.end - self.start).total_seconds() * 1000)
+
+
+class RequestState(BaseModel):
+    """
+    Transient state for a single request.
+
+    Lifecycle: Created at request start, discarded at request end.
+    Purpose: Track request metadata, timing, and intermediate results.
+
+    IMPORTANT: This state is NEVER persisted to disk.
+    It is garbage collected after the request completes.
+
+    Attributes:
+        request_id: Unique identifier for this request
+        session_id: Parent session identifier
+        user_id: Optional user identifier
+        source: Request source ("cli", "api", "cloud")
+        is_deep_research: Whether this is a deep research request
+        is_streaming: Whether streaming mode is enabled
+        steps: List of timing information for each step
+        current_step: Name of currently executing step
+        intermediate_response: Temporary response buffer
+        llm_thought: LLM reasoning (for thinking-enabled models)
+        tool_call_count: Number of tool invocations
+        errors: List of errors encountered
+        warnings: List of warnings generated
+    """
+
+    # Request identification
+    request_id: str = Field(description="Unique request identifier")
+    session_id: str = Field(description="Parent session ID")
+    user_id: Optional[str] = Field(default=None, description="User identifier")
+    source: Optional[str] = Field(
+        default=None, description="Request source: 'cli', 'api', or 'cloud'"
+    )
+
+    # Request type flags
+    is_deep_research: bool = Field(default=False, description="Deep research mode enabled")
+    is_streaming: bool = Field(default=False, description="Streaming mode enabled")
+
+    # Execution tracking
+    steps: List[StepTiming] = Field(
+        default_factory=list, description="Timing for each execution step"
+    )
+    current_step: Optional[str] = Field(
+        default=None, description="Currently executing step name"
+    )
+
+    # Intermediate results (not persisted)
+    intermediate_response: Optional[str] = Field(
+        default=None, description="Temporary response buffer"
+    )
+    llm_thought: Optional[str] = Field(
+        default=None, description="LLM reasoning for thinking-enabled models"
+    )
+    tool_call_count: int = Field(default=0, description="Number of tool invocations")
+
+    # Error tracking
+    errors: List[str] = Field(default_factory=list, description="Errors encountered")
+    warnings: List[str] = Field(default_factory=list, description="Warnings generated")
+
+    def start_step(self, step_name: str) -> None:
+        """
+        Start timing a new step.
+
+        Args:
+            step_name: Identifier for the step (e.g., "analysis", "export")
+        """
+        self.current_step = step_name
+        self.steps.append(StepTiming(name=step_name, start=datetime.utcnow()))
+
+    def end_step(self, step_name: str) -> Optional[int]:
+        """
+        End timing for a step and compute duration.
+
+        Args:
+            step_name: The step to complete
+
+        Returns:
+            Duration in milliseconds, or None if step not found
+        """
+        for step in reversed(self.steps):
+            if step.name == step_name and step.end is None:
+                step.complete()
+                if self.current_step == step_name:
+                    self.current_step = None
+                return step.duration_ms
+        return None
+
+    def get_step_duration(self, step_name: str) -> Optional[int]:
+        """
+        Get duration of a completed step in milliseconds.
+
+        Args:
+            step_name: The step to query
+
+        Returns:
+            Duration in milliseconds, or None if step not found/incomplete
+        """
+        for step in self.steps:
+            if step.name == step_name:
+                return step.duration_ms
+        return None
+
+    def get_total_duration(self) -> int:
+        """
+        Get total duration of all completed steps in milliseconds.
+
+        Returns:
+            Sum of all step durations
+        """
+        return sum(s.duration_ms or 0 for s in self.steps)
+
+    def add_error(self, error: str) -> None:
+        """Add an error message."""
+        self.errors.append(error)
+
+    def add_warning(self, warning: str) -> None:
+        """Add a warning message."""
+        self.warnings.append(warning)
+
+    def increment_tool_call(self) -> int:
+        """Increment tool call counter and return new count."""
+        self.tool_call_count += 1
+        return self.tool_call_count
+
+
+# =============================================================================
+# TIER 2: SESSION STATE (Persistent)
+# =============================================================================
+
+
+class ResearchProgress(BaseModel):
+    """
+    Track research progress across iterations.
+
+    Used for multi-turn research sessions where the system
+    iteratively refines hypotheses and accumulates insights.
+    """
+
+    iteration_count: int = Field(default=0, description="Current iteration number")
+    max_iterations: int = Field(default=5, description="Maximum allowed iterations")
+    mode: str = Field(
+        default="semi-autonomous",
+        description="Research mode: 'semi-autonomous', 'fully-autonomous', or 'steering'",
+    )
+    is_converged: bool = Field(default=False, description="Whether research has converged")
+    convergence_reason: Optional[str] = Field(
+        default=None, description="Reason for convergence (if converged)"
+    )
+
+
+class SessionState(BaseModel):
+    """
+    Persistent state for a research session.
+
+    Lifecycle: Created at session start, persisted across requests.
+    Purpose: Accumulate knowledge, track progress, enable multi-turn research.
+
+    Storage: Saved to `workspace/.session_state.json`
+
+    Attributes:
+        session_id: Unique session identifier
+        created_at: When session was created
+        updated_at: When session was last updated
+        objective: Main research question/goal
+        current_objective: Current iteration's focus (may evolve)
+        session_title: Human-readable session title
+        key_insights: Accumulated insights (max 10, most recent kept)
+        methodology: Current research methodology/approach
+        current_hypothesis: Latest generated hypothesis
+        discoveries: Structured scientific discoveries
+        progress: Research iteration progress
+        current_plan: Currently executing plan tasks
+        suggested_next_steps: Suggested tasks for next iteration
+        loaded_modalities: Names of loaded data modalities
+        uploaded_files: Uploaded file metadata
+    """
+
+    # Session identification
+    session_id: str = Field(description="Unique session identifier")
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow, description="Session creation timestamp"
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow, description="Last update timestamp"
+    )
+
+    # Research objectives
+    objective: str = Field(default="", description="Main research question/goal")
+    current_objective: Optional[str] = Field(
+        default=None, description="Current iteration's focus (may evolve)"
+    )
+    session_title: Optional[str] = Field(
+        default=None, description="Human-readable session title"
+    )
+
+    # Accumulated knowledge (CRITICAL - this is what persists)
+    key_insights: List[str] = Field(
+        default_factory=list, description="Max 10 prioritized insights from reflection"
+    )
+    methodology: Optional[str] = Field(
+        default=None, description="Current research methodology/approach"
+    )
+    current_hypothesis: Optional[str] = Field(
+        default=None, description="Latest generated hypothesis"
+    )
+    discoveries: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Structured scientific discoveries"
+    )
+
+    # Research progress
+    progress: ResearchProgress = Field(
+        default_factory=ResearchProgress, description="Research iteration progress"
+    )
+
+    # Plan state
+    current_plan: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Currently executing plan tasks"
+    )
+    suggested_next_steps: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Suggested tasks for next iteration"
+    )
+
+    # Data references (not the data itself, just names/metadata)
+    loaded_modalities: List[str] = Field(
+        default_factory=list, description="Names of loaded modalities"
+    )
+    uploaded_files: List[Dict[str, str]] = Field(
+        default_factory=list, description="Uploaded file metadata"
+    )
+
+    def add_insight(self, insight: str, max_insights: int = 10) -> None:
+        """
+        Add insight with maximum limit enforcement.
+
+        If insight already exists, it won't be duplicated.
+        If over limit, oldest insights are removed.
+
+        Args:
+            insight: The insight to add
+            max_insights: Maximum number of insights to keep (default: 10)
+        """
+        if insight and insight not in self.key_insights:
+            self.key_insights.append(insight)
+            # Keep only most recent if over limit
+            if len(self.key_insights) > max_insights:
+                self.key_insights = self.key_insights[-max_insights:]
+        self.updated_at = datetime.utcnow()
+
+    def update_hypothesis(self, hypothesis: str) -> None:
+        """
+        Update the current hypothesis.
+
+        Args:
+            hypothesis: The new hypothesis
+        """
+        self.current_hypothesis = hypothesis
+        self.updated_at = datetime.utcnow()
+
+    def update_methodology(self, methodology: str) -> None:
+        """
+        Update the research methodology.
+
+        Args:
+            methodology: The new methodology description
+        """
+        self.methodology = methodology
+        self.updated_at = datetime.utcnow()
+
+    def add_discovery(self, discovery: Dict[str, Any]) -> None:
+        """
+        Add a structured discovery.
+
+        Args:
+            discovery: Discovery dictionary with title, claim, summary, evidence
+        """
+        self.discoveries.append(discovery)
+        self.updated_at = datetime.utcnow()
+
+    def increment_iteration(self) -> bool:
+        """
+        Increment iteration count.
+
+        Returns:
+            True if can continue (under max), False if at limit
+        """
+        self.progress.iteration_count += 1
+        self.updated_at = datetime.utcnow()
+        return self.progress.iteration_count < self.progress.max_iterations
+
+    def mark_converged(self, reason: str) -> None:
+        """
+        Mark research as converged.
+
+        Args:
+            reason: Why research converged
+        """
+        self.progress.is_converged = True
+        self.progress.convergence_reason = reason
+        self.updated_at = datetime.utcnow()
+
+    def update_loaded_modalities(self, modality_names: List[str]) -> None:
+        """
+        Update the list of loaded modalities.
+
+        Args:
+            modality_names: List of modality names currently loaded
+        """
+        self.loaded_modalities = modality_names
+        self.updated_at = datetime.utcnow()
+
+    def get_context_summary(self) -> Dict[str, Any]:
+        """
+        Get a summary of session context for agent prompts.
+
+        Returns:
+            Dictionary with key context information
+        """
+        return {
+            "objective": self.objective,
+            "current_objective": self.current_objective,
+            "key_insights": self.key_insights[-5:] if self.key_insights else [],
+            "current_hypothesis": self.current_hypothesis,
+            "methodology": self.methodology,
+            "iteration": self.progress.iteration_count,
+            "is_converged": self.progress.is_converged,
+            "loaded_modalities": self.loaded_modalities,
+        }
+
+
+# =============================================================================
+# STATE MANAGER (Orchestrates Both Tiers)
+# =============================================================================
+
+
+class StateManager:
+    """
+    Manages two-tier state lifecycle.
+
+    Responsibilities:
+    - Create and discard transient RequestState (Tier 1)
+    - Load, save, and cache persistent SessionState (Tier 2)
+    - Handle thread-safe file I/O for session persistence
+
+    Usage:
+        state_manager = StateManager(workspace_path)
+
+        # Start request
+        request_state = state_manager.start_request(request_id)
+        session_state = state_manager.load_session(session_id)
+
+        # During processing
+        request_state.start_step("planning")
+        # ... agent work ...
+        request_state.end_step("planning")
+        session_state.add_insight("New finding about X")
+
+        # End request
+        state_manager.save_session(session_state)
+        summary = state_manager.end_request()  # request_state is discarded
+
+    Thread Safety:
+        - Session file I/O is protected by threading.Lock
+        - Session cache is thread-safe for read operations
+    """
+
+    STATE_FILE_NAME = ".session_state.json"
+
+    def __init__(self, workspace_path: str):
+        """
+        Initialize StateManager.
+
+        Args:
+            workspace_path: Path to the workspace directory
+        """
+        self.workspace_path = Path(workspace_path)
+        self._current_request: Optional[RequestState] = None
+        self._session_cache: Dict[str, SessionState] = {}
+        self._file_lock = threading.Lock()
+
+    def start_request(
+        self,
+        request_id: Optional[str] = None,
+        session_id: str = "",
+        **kwargs,
+    ) -> RequestState:
+        """
+        Create new transient request state.
+
+        Args:
+            request_id: Unique request ID (auto-generated if not provided)
+            session_id: Parent session ID
+            **kwargs: Additional RequestState fields (user_id, source, etc.)
+
+        Returns:
+            New RequestState instance
+        """
+        request_id = request_id or str(uuid.uuid4())
+        self._current_request = RequestState(
+            request_id=request_id, session_id=session_id, **kwargs
+        )
+        logger.debug(f"Started request: {request_id}")
+        return self._current_request
+
+    def get_current_request(self) -> Optional[RequestState]:
+        """
+        Get current request state.
+
+        Returns:
+            Current RequestState or None if no active request
+        """
+        return self._current_request
+
+    def end_request(self) -> Dict[str, Any]:
+        """
+        End request and return timing summary.
+
+        The request state is discarded after this call.
+
+        Returns:
+            Dictionary with timing summary:
+            - request_id: The request identifier
+            - total_duration_ms: Total duration of all steps
+            - steps: List of step timing info
+            - tool_calls: Number of tool invocations
+            - errors: List of errors encountered
+        """
+        if self._current_request is None:
+            return {}
+
+        summary = {
+            "request_id": self._current_request.request_id,
+            "total_duration_ms": self._current_request.get_total_duration(),
+            "steps": [
+                {"name": s.name, "duration_ms": s.duration_ms}
+                for s in self._current_request.steps
+            ],
+            "tool_calls": self._current_request.tool_call_count,
+            "errors": self._current_request.errors,
+            "warnings": self._current_request.warnings,
+        }
+
+        logger.debug(
+            f"Ended request: {self._current_request.request_id} "
+            f"(duration: {summary['total_duration_ms']}ms)"
+        )
+
+        # Discard transient state
+        self._current_request = None
+        return summary
+
+    def load_session(self, session_id: str, objective: str = "") -> SessionState:
+        """
+        Load or create persistent session state.
+
+        If session exists in cache or on disk, it is loaded.
+        Otherwise, a new session is created.
+
+        Args:
+            session_id: Session identifier
+            objective: Initial research objective (for new sessions)
+
+        Returns:
+            SessionState instance
+        """
+        # Check cache first
+        if session_id in self._session_cache:
+            logger.debug(f"Loaded session from cache: {session_id}")
+            return self._session_cache[session_id]
+
+        # Try to load from disk
+        state_file = self.workspace_path / self.STATE_FILE_NAME
+        if state_file.exists():
+            try:
+                with self._file_lock:
+                    with open(state_file, "r") as f:
+                        data = json.load(f)
+
+                # Handle datetime fields
+                if "created_at" in data and isinstance(data["created_at"], str):
+                    data["created_at"] = datetime.fromisoformat(
+                        data["created_at"].replace("Z", "+00:00")
+                    )
+                if "updated_at" in data and isinstance(data["updated_at"], str):
+                    data["updated_at"] = datetime.fromisoformat(
+                        data["updated_at"].replace("Z", "+00:00")
+                    )
+
+                session = SessionState(**data)
+                self._session_cache[session_id] = session
+                logger.debug(f"Loaded session from disk: {session_id}")
+                return session
+
+            except Exception as e:
+                logger.warning(f"Could not load session from disk: {e}")
+                # Fall through to create new
+
+        # Create new session state
+        session = SessionState(session_id=session_id, objective=objective)
+        self._session_cache[session_id] = session
+        logger.debug(f"Created new session: {session_id}")
+        return session
+
+    def save_session(self, session: SessionState) -> None:
+        """
+        Persist session state to disk.
+
+        Args:
+            session: The SessionState to save
+        """
+        session.updated_at = datetime.utcnow()
+        state_file = self.workspace_path / self.STATE_FILE_NAME
+
+        # Ensure directory exists
+        self.workspace_path.mkdir(parents=True, exist_ok=True)
+
+        with self._file_lock:
+            with open(state_file, "w") as f:
+                json.dump(
+                    session.model_dump(mode="json"),
+                    f,
+                    indent=2,
+                    default=str,
+                )
+
+        # Update cache
+        self._session_cache[session.session_id] = session
+        logger.debug(f"Saved session to disk: {session.session_id}")
+
+    def clear_session_cache(self) -> None:
+        """Clear the in-memory session cache."""
+        self._session_cache.clear()
+        logger.debug("Cleared session cache")
+
+    def delete_session_file(self) -> bool:
+        """
+        Delete the session state file from disk.
+
+        Returns:
+            True if file was deleted, False if it didn't exist
+        """
+        state_file = self.workspace_path / self.STATE_FILE_NAME
+        if state_file.exists():
+            with self._file_lock:
+                state_file.unlink()
+            logger.debug("Deleted session state file")
+            return True
+        return False
+
+
+# =============================================================================
+# CONVENIENCE FUNCTIONS
+# =============================================================================
+
+
+def create_request_state(
+    session_id: str,
+    request_id: Optional[str] = None,
+    source: str = "cli",
+) -> RequestState:
+    """
+    Convenience function to create a RequestState.
+
+    Args:
+        session_id: Parent session ID
+        request_id: Unique request ID (auto-generated if not provided)
+        source: Request source ("cli", "api", "cloud")
+
+    Returns:
+        New RequestState instance
+    """
+    return RequestState(
+        request_id=request_id or str(uuid.uuid4()),
+        session_id=session_id,
+        source=source,
+    )
+
+
+def create_session_state(
+    session_id: Optional[str] = None,
+    objective: str = "",
+) -> SessionState:
+    """
+    Convenience function to create a SessionState.
+
+    Args:
+        session_id: Session ID (auto-generated if not provided)
+        objective: Initial research objective
+
+    Returns:
+        New SessionState instance
+    """
+    return SessionState(
+        session_id=session_id or str(uuid.uuid4()),
+        objective=objective,
+    )

--- a/tests/integration/test_state_lifecycle.py
+++ b/tests/integration/test_state_lifecycle.py
@@ -1,0 +1,448 @@
+"""
+Integration tests for Two-Tier State lifecycle through DataManagerV2.
+
+Tests cover:
+- State persistence across DataManagerV2 instances
+- Request lifecycle through DataManagerV2
+- Session state accumulation across multiple requests
+- .session_state.json file format and content
+"""
+
+import json
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from lobster.core.data_manager_v2 import DataManagerV2
+
+
+class TestStateLifecycleThroughDataManager:
+    """Integration tests for state management via DataManagerV2."""
+
+    def test_data_manager_has_state_manager(self):
+        """Test that DataManagerV2 initializes with StateManager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            assert dm._state_manager is not None
+            assert dm._session_state is None  # Lazy loaded
+            assert dm._request_state is None  # No active request
+
+    def test_data_manager_start_request(self):
+        """Test starting a request through DataManagerV2."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            request = dm.start_request(request_id="req-123", source="test")
+
+            assert request is not None
+            assert request.request_id == "req-123"
+            assert request.source == "test"
+            assert dm.request_state is request
+
+    def test_data_manager_request_state_property(self):
+        """Test request_state property."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            # No request yet
+            assert dm.request_state is None
+
+            # Start request
+            dm.start_request()
+            assert dm.request_state is not None
+
+    def test_data_manager_end_request(self):
+        """Test ending a request through DataManagerV2."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.start_request(request_id="req-123")
+            dm.request_state.start_step("test_step")
+            time.sleep(0.01)
+            dm.request_state.end_step("test_step")
+
+            summary = dm.end_request()
+
+            assert summary["request_id"] == "req-123"
+            assert summary["total_duration_ms"] >= 10
+            assert dm.request_state is None
+
+    def test_data_manager_session_state_lazy_load(self):
+        """Test that session_state is lazily loaded."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            # Not loaded yet
+            assert dm._session_state is None
+
+            # Access triggers load
+            session = dm.session_state
+            assert session is not None
+            assert dm._session_state is session
+
+    def test_data_manager_init_session_state(self):
+        """Test initializing session state with objective."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            session = dm.init_session_state(objective="Analyze cancer data")
+
+            assert session.objective == "Analyze cancer data"
+            assert dm.session_state is session
+
+    def test_data_manager_add_insight(self):
+        """Test adding insights through DataManagerV2."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.add_insight("Gene X is upregulated")
+            dm.add_insight("Gene Y is downregulated")
+
+            insights = dm.get_key_insights()
+            assert len(insights) == 2
+            assert "Gene X is upregulated" in insights
+
+    def test_data_manager_update_hypothesis(self):
+        """Test updating hypothesis through DataManagerV2."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.update_hypothesis("Gene X causes cancer")
+
+            hypothesis = dm.get_current_hypothesis()
+            assert hypothesis == "Gene X causes cancer"
+
+    def test_data_manager_save_session_state(self):
+        """Test explicitly saving session state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.add_insight("Test insight")
+            dm.save_session_state()
+
+            # Verify file exists
+            state_file = Path(tmpdir) / ".session_state.json"
+            assert state_file.exists()
+
+    def test_data_manager_get_session_context(self):
+        """Test getting session context summary."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.init_session_state(objective="Test objective")
+            dm.add_insight("Insight 1")
+            dm.update_hypothesis("Test hypothesis")
+
+            context = dm.get_session_context()
+
+            assert context["objective"] == "Test objective"
+            assert context["current_hypothesis"] == "Test hypothesis"
+            assert len(context["key_insights"]) == 1
+
+
+class TestStatePersistenceAcrossInstances:
+    """Test state persistence across DataManagerV2 instances."""
+
+    def test_session_state_persists_across_instances(self):
+        """Test that session state survives DataManagerV2 recreation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # First instance
+            dm1 = DataManagerV2(workspace_path=tmpdir)
+            dm1.init_session_state(objective="Original objective")
+            dm1.add_insight("Insight from session 1")
+            dm1.update_hypothesis("Initial hypothesis")
+            dm1.save_session_state()
+
+            # Second instance (same workspace)
+            dm2 = DataManagerV2(workspace_path=tmpdir)
+
+            # Session state should be loaded from disk
+            # Note: This will create a new session_id, but load existing state file
+            session = dm2.session_state
+
+            # The state file was saved, so it should have the insights
+            # However, session_id will be different
+            assert "Insight from session 1" in session.key_insights
+            assert session.current_hypothesis == "Initial hypothesis"
+
+    def test_request_state_does_not_persist(self):
+        """Test that request state is NOT persisted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # First instance with request
+            dm1 = DataManagerV2(workspace_path=tmpdir)
+            dm1.start_request(request_id="req-123")
+            dm1.request_state.start_step("test")
+            # Don't end request - simulate crash
+
+            # Second instance
+            dm2 = DataManagerV2(workspace_path=tmpdir)
+
+            # Request state should be None (transient)
+            assert dm2.request_state is None
+
+    def test_multiple_requests_accumulate_insights(self):
+        """Test that insights accumulate across multiple requests."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            # First request
+            dm.start_request(request_id="req-1")
+            dm.add_insight("Insight from request 1")
+            dm.end_request()
+
+            # Second request
+            dm.start_request(request_id="req-2")
+            dm.add_insight("Insight from request 2")
+            dm.end_request()
+
+            # Third request
+            dm.start_request(request_id="req-3")
+            dm.add_insight("Insight from request 3")
+            dm.end_request()
+
+            insights = dm.get_key_insights()
+            assert len(insights) == 3
+            assert "Insight from request 1" in insights
+            assert "Insight from request 2" in insights
+            assert "Insight from request 3" in insights
+
+
+class TestSessionStateFileFormat:
+    """Test .session_state.json file format and content."""
+
+    def test_session_state_file_format(self):
+        """Test that session state file has expected format."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.init_session_state(objective="Test objective")
+            dm.add_insight("Test insight")
+            dm.update_hypothesis("Test hypothesis")
+            dm.session_state.update_methodology("Test methodology")
+            dm.session_state.add_discovery({"title": "Discovery 1"})
+            dm.save_session_state()
+
+            # Read file
+            state_file = Path(tmpdir) / ".session_state.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Verify structure
+            assert "session_id" in data
+            assert "created_at" in data
+            assert "updated_at" in data
+            assert "objective" in data
+            assert "key_insights" in data
+            assert "methodology" in data
+            assert "current_hypothesis" in data
+            assert "discoveries" in data
+            assert "progress" in data
+            assert "loaded_modalities" in data
+
+            # Verify content
+            assert data["objective"] == "Test objective"
+            assert "Test insight" in data["key_insights"]
+            assert data["current_hypothesis"] == "Test hypothesis"
+            assert data["methodology"] == "Test methodology"
+            assert len(data["discoveries"]) == 1
+
+    def test_session_state_file_is_valid_json(self):
+        """Test that session state file is valid JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            # Add various types of data
+            dm.init_session_state(objective="Test")
+            dm.add_insight("Insight")
+            dm.session_state.update_loaded_modalities(["mod1", "mod2"])
+            dm.session_state.increment_iteration()
+            dm.save_session_state()
+
+            # Should not raise
+            state_file = Path(tmpdir) / ".session_state.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert isinstance(data, dict)
+
+    def test_session_state_progress_tracking(self):
+        """Test that progress tracking is persisted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.session_state.increment_iteration()
+            dm.session_state.increment_iteration()
+            dm.session_state.mark_converged("Found answer")
+            dm.save_session_state()
+
+            # Read file
+            state_file = Path(tmpdir) / ".session_state.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["progress"]["iteration_count"] == 2
+            assert data["progress"]["is_converged"] is True
+            assert data["progress"]["convergence_reason"] == "Found answer"
+
+
+class TestRequestTimingIntegration:
+    """Test request timing through DataManagerV2."""
+
+    def test_request_timing_single_step(self):
+        """Test timing a single step."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.start_request(request_id="req-123")
+            dm.request_state.start_step("analysis")
+            time.sleep(0.05)  # 50ms
+            dm.request_state.end_step("analysis")
+
+            summary = dm.end_request()
+
+            assert summary["total_duration_ms"] >= 50
+            assert len(summary["steps"]) == 1
+            assert summary["steps"][0]["name"] == "analysis"
+            assert summary["steps"][0]["duration_ms"] >= 50
+
+    def test_request_timing_multiple_steps(self):
+        """Test timing multiple sequential steps."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.start_request(request_id="req-123")
+
+            dm.request_state.start_step("planning")
+            time.sleep(0.02)
+            dm.request_state.end_step("planning")
+
+            dm.request_state.start_step("execution")
+            time.sleep(0.03)
+            dm.request_state.end_step("execution")
+
+            dm.request_state.start_step("export")
+            time.sleep(0.01)
+            dm.request_state.end_step("export")
+
+            summary = dm.end_request()
+
+            assert len(summary["steps"]) == 3
+            assert summary["total_duration_ms"] >= 60  # At least 60ms total
+
+    def test_request_error_tracking(self):
+        """Test error tracking in request state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.start_request(request_id="req-123")
+            dm.request_state.add_error("Error 1")
+            dm.request_state.add_error("Error 2")
+            dm.request_state.add_warning("Warning 1")
+
+            summary = dm.end_request()
+
+            assert len(summary["errors"]) == 2
+            assert "Error 1" in summary["errors"]
+            assert "Warning 1" in summary["warnings"]
+
+    def test_request_tool_call_counting(self):
+        """Test tool call counting in request state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.start_request(request_id="req-123")
+            dm.request_state.increment_tool_call()
+            dm.request_state.increment_tool_call()
+            dm.request_state.increment_tool_call()
+
+            summary = dm.end_request()
+
+            assert summary["tool_calls"] == 3
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_end_request_without_start(self):
+        """Test ending request when none is active."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            summary = dm.end_request()
+
+            assert summary == {}
+
+    def test_multiple_start_requests_overwrites(self):
+        """Test that starting a new request overwrites the previous."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            request1 = dm.start_request(request_id="req-1")
+            request2 = dm.start_request(request_id="req-2")
+
+            assert dm.request_state.request_id == "req-2"
+            assert dm.request_state is request2
+
+    def test_session_state_handles_corrupted_file(self):
+        """Test that session state handles corrupted file gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write corrupted file
+            state_file = Path(tmpdir) / ".session_state.json"
+            with open(state_file, "w") as f:
+                f.write("{ invalid json }")
+
+            # Should create new session without raising
+            dm = DataManagerV2(workspace_path=tmpdir)
+            session = dm.session_state
+
+            assert session is not None
+            assert session.session_id is not None
+
+    def test_insight_limit_enforced(self):
+        """Test that insight limit is enforced."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            # Add 20 insights (more than max 10)
+            for i in range(20):
+                dm.add_insight(f"Insight {i}")
+
+            insights = dm.get_key_insights()
+            assert len(insights) == 10
+
+            # Should keep most recent
+            assert "Insight 19" in insights
+            assert "Insight 0" not in insights
+
+    def test_empty_workspace_creates_state_file(self):
+        """Test that state file is created in empty workspace."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            dm.init_session_state(objective="Test")
+            dm.save_session_state()
+
+            state_file = Path(tmpdir) / ".session_state.json"
+            assert state_file.exists()
+
+    def test_session_state_with_special_characters(self):
+        """Test session state handles special characters."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dm = DataManagerV2(workspace_path=tmpdir)
+
+            # Add insights with special characters
+            dm.add_insight("Gene expression: p-value < 0.05 (FDR)")
+            dm.add_insight("Pathway: NF-\u03baB signaling")  # Unicode
+            dm.update_hypothesis("H\u2080: No difference exists")
+
+            dm.save_session_state()
+
+            # Reload and verify
+            dm2 = DataManagerV2(workspace_path=tmpdir)
+            insights = dm2.get_key_insights()
+
+            assert "Gene expression: p-value < 0.05 (FDR)" in insights
+            assert "Pathway: NF-\u03baB signaling" in insights

--- a/tests/unit/core/test_state.py
+++ b/tests/unit/core/test_state.py
@@ -1,0 +1,768 @@
+"""
+Unit tests for Two-Tier State Management.
+
+Tests cover:
+- StepTiming: timing calculations
+- RequestState: lifecycle, timing, error tracking
+- SessionState: persistence, insight accumulation, hypothesis updates
+- StateManager: orchestration, file I/O, caching
+"""
+
+import json
+import tempfile
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lobster.core.schemas.state import (
+    RequestState,
+    ResearchProgress,
+    SessionState,
+    StateManager,
+    StepTiming,
+    create_request_state,
+    create_session_state,
+)
+
+
+# =============================================================================
+# StepTiming Tests
+# =============================================================================
+
+
+class TestStepTiming:
+    """Tests for StepTiming model."""
+
+    def test_step_timing_creation(self):
+        """Test creating a StepTiming instance."""
+        now = datetime.utcnow()
+        step = StepTiming(name="analysis", start=now)
+
+        assert step.name == "analysis"
+        assert step.start == now
+        assert step.end is None
+        assert step.duration_ms is None
+
+    def test_step_timing_complete(self):
+        """Test completing a step and computing duration."""
+        step = StepTiming(name="analysis", start=datetime.utcnow())
+        time.sleep(0.01)  # Small delay to ensure measurable duration
+        step.complete()
+
+        assert step.end is not None
+        assert step.duration_ms is not None
+        assert step.duration_ms >= 10  # At least 10ms
+
+    def test_step_timing_complete_duration_calculation(self):
+        """Test duration calculation is accurate."""
+        start = datetime.utcnow()
+        step = StepTiming(name="test", start=start)
+
+        # Manually set end time to test calculation
+        step.end = start + timedelta(milliseconds=500)
+        step.duration_ms = int((step.end - step.start).total_seconds() * 1000)
+
+        assert step.duration_ms == 500
+
+
+# =============================================================================
+# RequestState Tests
+# =============================================================================
+
+
+class TestRequestState:
+    """Tests for RequestState (Tier 1 - Transient)."""
+
+    def test_request_state_creation(self):
+        """Test creating a RequestState instance."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+
+        assert state.request_id == "req-123"
+        assert state.session_id == "sess-456"
+        assert state.user_id is None
+        assert state.source is None
+        assert state.is_deep_research is False
+        assert state.is_streaming is False
+        assert state.steps == []
+        assert state.current_step is None
+        assert state.tool_call_count == 0
+        assert state.errors == []
+        assert state.warnings == []
+
+    def test_request_state_with_optional_fields(self):
+        """Test RequestState with optional fields set."""
+        state = RequestState(
+            request_id="req-123",
+            session_id="sess-456",
+            user_id="user-1",
+            source="cli",
+            is_deep_research=True,
+            is_streaming=True,
+        )
+
+        assert state.user_id == "user-1"
+        assert state.source == "cli"
+        assert state.is_deep_research is True
+        assert state.is_streaming is True
+
+    def test_request_state_start_step(self):
+        """Test starting a step."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        state.start_step("analysis")
+
+        assert state.current_step == "analysis"
+        assert len(state.steps) == 1
+        assert state.steps[0].name == "analysis"
+        assert state.steps[0].start is not None
+        assert state.steps[0].end is None
+
+    def test_request_state_end_step(self):
+        """Test ending a step."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        state.start_step("analysis")
+        time.sleep(0.01)
+        duration = state.end_step("analysis")
+
+        assert state.current_step is None
+        assert state.steps[0].end is not None
+        assert duration is not None
+        assert duration >= 10
+
+    def test_request_state_end_nonexistent_step(self):
+        """Test ending a step that doesn't exist."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        duration = state.end_step("nonexistent")
+
+        assert duration is None
+
+    def test_request_state_multiple_steps(self):
+        """Test tracking multiple steps."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+
+        state.start_step("planning")
+        time.sleep(0.01)
+        state.end_step("planning")
+
+        state.start_step("execution")
+        time.sleep(0.01)
+        state.end_step("execution")
+
+        assert len(state.steps) == 2
+        assert state.steps[0].name == "planning"
+        assert state.steps[1].name == "execution"
+        assert state.steps[0].duration_ms is not None
+        assert state.steps[1].duration_ms is not None
+
+    def test_request_state_get_step_duration(self):
+        """Test getting duration of a specific step."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        state.start_step("analysis")
+        time.sleep(0.01)
+        state.end_step("analysis")
+
+        duration = state.get_step_duration("analysis")
+        assert duration is not None
+        assert duration >= 10
+
+    def test_request_state_get_step_duration_not_found(self):
+        """Test getting duration of nonexistent step."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        duration = state.get_step_duration("nonexistent")
+        assert duration is None
+
+    def test_request_state_get_total_duration(self):
+        """Test getting total duration of all steps."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+
+        state.start_step("step1")
+        time.sleep(0.01)
+        state.end_step("step1")
+
+        state.start_step("step2")
+        time.sleep(0.01)
+        state.end_step("step2")
+
+        total = state.get_total_duration()
+        assert total >= 20  # At least 20ms total
+
+    def test_request_state_add_error(self):
+        """Test adding errors."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        state.add_error("Error 1")
+        state.add_error("Error 2")
+
+        assert len(state.errors) == 2
+        assert state.errors[0] == "Error 1"
+        assert state.errors[1] == "Error 2"
+
+    def test_request_state_add_warning(self):
+        """Test adding warnings."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        state.add_warning("Warning 1")
+
+        assert len(state.warnings) == 1
+        assert state.warnings[0] == "Warning 1"
+
+    def test_request_state_increment_tool_call(self):
+        """Test incrementing tool call counter."""
+        state = RequestState(request_id="req-123", session_id="sess-456")
+        assert state.tool_call_count == 0
+
+        count = state.increment_tool_call()
+        assert count == 1
+        assert state.tool_call_count == 1
+
+        count = state.increment_tool_call()
+        assert count == 2
+
+
+# =============================================================================
+# ResearchProgress Tests
+# =============================================================================
+
+
+class TestResearchProgress:
+    """Tests for ResearchProgress model."""
+
+    def test_research_progress_defaults(self):
+        """Test default values."""
+        progress = ResearchProgress()
+
+        assert progress.iteration_count == 0
+        assert progress.max_iterations == 5
+        assert progress.mode == "semi-autonomous"
+        assert progress.is_converged is False
+        assert progress.convergence_reason is None
+
+    def test_research_progress_custom_values(self):
+        """Test custom values."""
+        progress = ResearchProgress(
+            iteration_count=3,
+            max_iterations=10,
+            mode="fully-autonomous",
+            is_converged=True,
+            convergence_reason="Found answer",
+        )
+
+        assert progress.iteration_count == 3
+        assert progress.max_iterations == 10
+        assert progress.mode == "fully-autonomous"
+        assert progress.is_converged is True
+        assert progress.convergence_reason == "Found answer"
+
+
+# =============================================================================
+# SessionState Tests
+# =============================================================================
+
+
+class TestSessionState:
+    """Tests for SessionState (Tier 2 - Persistent)."""
+
+    def test_session_state_creation(self):
+        """Test creating a SessionState instance."""
+        state = SessionState(session_id="sess-123")
+
+        assert state.session_id == "sess-123"
+        assert state.objective == ""
+        assert state.current_objective is None
+        assert state.session_title is None
+        assert state.key_insights == []
+        assert state.methodology is None
+        assert state.current_hypothesis is None
+        assert state.discoveries == []
+        assert state.current_plan == []
+        assert state.suggested_next_steps == []
+        assert state.loaded_modalities == []
+        assert state.uploaded_files == []
+
+    def test_session_state_with_objective(self):
+        """Test SessionState with objective set."""
+        state = SessionState(
+            session_id="sess-123",
+            objective="Analyze gene expression in cancer cells",
+        )
+
+        assert state.objective == "Analyze gene expression in cancer cells"
+
+    def test_session_state_add_insight(self):
+        """Test adding insights."""
+        state = SessionState(session_id="sess-123")
+        state.add_insight("Gene X is upregulated")
+        state.add_insight("Gene Y is downregulated")
+
+        assert len(state.key_insights) == 2
+        assert state.key_insights[0] == "Gene X is upregulated"
+        assert state.key_insights[1] == "Gene Y is downregulated"
+
+    def test_session_state_add_insight_no_duplicates(self):
+        """Test that duplicate insights are not added."""
+        state = SessionState(session_id="sess-123")
+        state.add_insight("Gene X is upregulated")
+        state.add_insight("Gene X is upregulated")  # Duplicate
+
+        assert len(state.key_insights) == 1
+
+    def test_session_state_add_insight_max_limit(self):
+        """Test that insights are limited to max_insights."""
+        state = SessionState(session_id="sess-123")
+
+        # Add 15 insights (more than default max of 10)
+        for i in range(15):
+            state.add_insight(f"Insight {i}")
+
+        assert len(state.key_insights) == 10
+        # Should keep most recent
+        assert state.key_insights[0] == "Insight 5"
+        assert state.key_insights[-1] == "Insight 14"
+
+    def test_session_state_add_insight_custom_max(self):
+        """Test custom max_insights limit."""
+        state = SessionState(session_id="sess-123")
+
+        for i in range(10):
+            state.add_insight(f"Insight {i}", max_insights=5)
+
+        assert len(state.key_insights) == 5
+
+    def test_session_state_add_insight_empty_string(self):
+        """Test that empty insights are not added."""
+        state = SessionState(session_id="sess-123")
+        state.add_insight("")
+        state.add_insight("   ")  # Whitespace is kept if non-empty
+
+        # Empty string should not be added, but whitespace will be
+        assert "" not in state.key_insights
+
+    def test_session_state_update_hypothesis(self):
+        """Test updating hypothesis."""
+        state = SessionState(session_id="sess-123")
+        state.update_hypothesis("Gene X causes cancer")
+
+        assert state.current_hypothesis == "Gene X causes cancer"
+
+    def test_session_state_update_methodology(self):
+        """Test updating methodology."""
+        state = SessionState(session_id="sess-123")
+        state.update_methodology("Use differential expression analysis")
+
+        assert state.methodology == "Use differential expression analysis"
+
+    def test_session_state_add_discovery(self):
+        """Test adding discoveries."""
+        state = SessionState(session_id="sess-123")
+        discovery = {
+            "title": "Gene X Discovery",
+            "claim": "Gene X is a key regulator",
+            "summary": "Detailed analysis shows...",
+            "evidence": ["Figure 1", "Table 2"],
+        }
+        state.add_discovery(discovery)
+
+        assert len(state.discoveries) == 1
+        assert state.discoveries[0]["title"] == "Gene X Discovery"
+
+    def test_session_state_increment_iteration(self):
+        """Test incrementing iteration count."""
+        state = SessionState(session_id="sess-123")
+
+        # Should return True while under max
+        assert state.increment_iteration() is True
+        assert state.progress.iteration_count == 1
+
+        # Continue until max
+        for _ in range(3):
+            state.increment_iteration()
+
+        assert state.progress.iteration_count == 4
+
+        # At max (5 iterations), should return False
+        assert state.increment_iteration() is False
+        assert state.progress.iteration_count == 5
+
+    def test_session_state_mark_converged(self):
+        """Test marking research as converged."""
+        state = SessionState(session_id="sess-123")
+        state.mark_converged("Found conclusive evidence")
+
+        assert state.progress.is_converged is True
+        assert state.progress.convergence_reason == "Found conclusive evidence"
+
+    def test_session_state_update_loaded_modalities(self):
+        """Test updating loaded modalities list."""
+        state = SessionState(session_id="sess-123")
+        state.update_loaded_modalities(["geo_gse123", "geo_gse456"])
+
+        assert state.loaded_modalities == ["geo_gse123", "geo_gse456"]
+
+    def test_session_state_get_context_summary(self):
+        """Test getting context summary for agent prompts."""
+        state = SessionState(
+            session_id="sess-123",
+            objective="Analyze cancer data",
+        )
+        state.add_insight("Insight 1")
+        state.add_insight("Insight 2")
+        state.update_hypothesis("Gene X is key")
+        state.update_methodology("Use DESeq2")
+        state.update_loaded_modalities(["modality1"])
+        state.increment_iteration()
+
+        summary = state.get_context_summary()
+
+        assert summary["objective"] == "Analyze cancer data"
+        assert summary["current_hypothesis"] == "Gene X is key"
+        assert summary["methodology"] == "Use DESeq2"
+        assert len(summary["key_insights"]) == 2
+        assert summary["iteration"] == 1
+        assert summary["is_converged"] is False
+        assert summary["loaded_modalities"] == ["modality1"]
+
+    def test_session_state_updated_at_timestamp(self):
+        """Test that updated_at is updated on mutations."""
+        state = SessionState(session_id="sess-123")
+        original_time = state.updated_at
+
+        time.sleep(0.01)
+        state.add_insight("New insight")
+
+        assert state.updated_at > original_time
+
+
+# =============================================================================
+# StateManager Tests
+# =============================================================================
+
+
+class TestStateManager:
+    """Tests for StateManager orchestration."""
+
+    def test_state_manager_creation(self):
+        """Test creating a StateManager instance."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+
+            assert manager.workspace_path == Path(tmpdir)
+            assert manager._current_request is None
+            assert manager._session_cache == {}
+
+    def test_state_manager_start_request(self):
+        """Test starting a request."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            request = manager.start_request(
+                request_id="req-123",
+                session_id="sess-456",
+                source="cli",
+            )
+
+            assert request.request_id == "req-123"
+            assert request.session_id == "sess-456"
+            assert request.source == "cli"
+            assert manager._current_request is request
+
+    def test_state_manager_start_request_auto_id(self):
+        """Test starting a request with auto-generated ID."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            request = manager.start_request(session_id="sess-456")
+
+            assert request.request_id is not None
+            assert len(request.request_id) == 36  # UUID format
+
+    def test_state_manager_get_current_request(self):
+        """Test getting current request."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+
+            # No request yet
+            assert manager.get_current_request() is None
+
+            # Start request
+            manager.start_request(session_id="sess-456")
+            assert manager.get_current_request() is not None
+
+    def test_state_manager_end_request(self):
+        """Test ending a request."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            manager.start_request(request_id="req-123", session_id="sess-456")
+
+            # Add a step
+            manager._current_request.start_step("test")
+            time.sleep(0.01)
+            manager._current_request.end_step("test")
+
+            # End request
+            summary = manager.end_request()
+
+            assert summary["request_id"] == "req-123"
+            assert summary["total_duration_ms"] >= 10
+            assert len(summary["steps"]) == 1
+            assert summary["steps"][0]["name"] == "test"
+            assert manager._current_request is None
+
+    def test_state_manager_end_request_no_active(self):
+        """Test ending request when none is active."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            summary = manager.end_request()
+
+            assert summary == {}
+
+    def test_state_manager_load_session_new(self):
+        """Test loading a new session."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            session = manager.load_session(
+                session_id="sess-123",
+                objective="Test objective",
+            )
+
+            assert session.session_id == "sess-123"
+            assert session.objective == "Test objective"
+            assert "sess-123" in manager._session_cache
+
+    def test_state_manager_load_session_from_cache(self):
+        """Test loading session from cache."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+
+            # First load
+            session1 = manager.load_session(session_id="sess-123")
+
+            # Second load should return cached
+            session2 = manager.load_session(session_id="sess-123")
+
+            assert session1 is session2
+
+    def test_state_manager_save_session(self):
+        """Test saving session to disk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            session = manager.load_session(session_id="sess-123")
+            session.add_insight("Test insight")
+            session.update_hypothesis("Test hypothesis")
+
+            manager.save_session(session)
+
+            # Verify file exists
+            state_file = Path(tmpdir) / ".session_state.json"
+            assert state_file.exists()
+
+            # Verify content
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["session_id"] == "sess-123"
+            assert "Test insight" in data["key_insights"]
+            assert data["current_hypothesis"] == "Test hypothesis"
+
+    def test_state_manager_load_session_from_disk(self):
+        """Test loading session from disk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Save session
+            manager1 = StateManager(tmpdir)
+            session1 = manager1.load_session(session_id="sess-123")
+            session1.add_insight("Test insight")
+            manager1.save_session(session1)
+
+            # Clear cache and reload
+            manager1.clear_session_cache()
+            session2 = manager1.load_session(session_id="sess-123")
+
+            assert session2.session_id == "sess-123"
+            assert "Test insight" in session2.key_insights
+
+    def test_state_manager_clear_session_cache(self):
+        """Test clearing session cache."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            manager.load_session(session_id="sess-123")
+            assert len(manager._session_cache) == 1
+
+            manager.clear_session_cache()
+            assert len(manager._session_cache) == 0
+
+    def test_state_manager_delete_session_file(self):
+        """Test deleting session file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            session = manager.load_session(session_id="sess-123")
+            manager.save_session(session)
+
+            state_file = Path(tmpdir) / ".session_state.json"
+            assert state_file.exists()
+
+            result = manager.delete_session_file()
+            assert result is True
+            assert not state_file.exists()
+
+    def test_state_manager_delete_session_file_nonexistent(self):
+        """Test deleting nonexistent session file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            result = manager.delete_session_file()
+            assert result is False
+
+    def test_state_manager_thread_safety(self):
+        """Test thread-safe session file access."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(tmpdir)
+            session = manager.load_session(session_id="sess-123")
+
+            errors = []
+
+            def save_session():
+                try:
+                    for _ in range(10):
+                        session.add_insight(f"Insight from {threading.current_thread().name}")
+                        manager.save_session(session)
+                except Exception as e:
+                    errors.append(e)
+
+            threads = [
+                threading.Thread(target=save_session, name=f"Thread-{i}")
+                for i in range(5)
+            ]
+
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            # No errors should occur
+            assert len(errors) == 0
+
+            # File should be valid JSON
+            state_file = Path(tmpdir) / ".session_state.json"
+            with open(state_file) as f:
+                data = json.load(f)
+            assert data["session_id"] == "sess-123"
+
+
+# =============================================================================
+# Convenience Function Tests
+# =============================================================================
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience functions."""
+
+    def test_create_request_state(self):
+        """Test create_request_state convenience function."""
+        state = create_request_state(
+            session_id="sess-123",
+            source="api",
+        )
+
+        assert state.session_id == "sess-123"
+        assert state.source == "api"
+        assert state.request_id is not None
+
+    def test_create_request_state_with_id(self):
+        """Test create_request_state with custom request_id."""
+        state = create_request_state(
+            session_id="sess-123",
+            request_id="custom-req-id",
+        )
+
+        assert state.request_id == "custom-req-id"
+
+    def test_create_session_state(self):
+        """Test create_session_state convenience function."""
+        state = create_session_state(objective="Test objective")
+
+        assert state.session_id is not None
+        assert state.objective == "Test objective"
+
+    def test_create_session_state_with_id(self):
+        """Test create_session_state with custom session_id."""
+        state = create_session_state(
+            session_id="custom-sess-id",
+            objective="Test objective",
+        )
+
+        assert state.session_id == "custom-sess-id"
+
+
+# =============================================================================
+# JSON Serialization Tests
+# =============================================================================
+
+
+class TestJsonSerialization:
+    """Tests for JSON serialization of state objects."""
+
+    def test_request_state_serialization(self):
+        """Test RequestState can be serialized to JSON."""
+        state = RequestState(
+            request_id="req-123",
+            session_id="sess-456",
+            source="cli",
+        )
+        state.start_step("test")
+        state.end_step("test")
+        state.add_error("Test error")
+
+        # Should not raise
+        json_data = state.model_dump(mode="json")
+        json_str = json.dumps(json_data, default=str)
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert parsed["request_id"] == "req-123"
+
+    def test_session_state_serialization(self):
+        """Test SessionState can be serialized to JSON."""
+        state = SessionState(
+            session_id="sess-123",
+            objective="Test objective",
+        )
+        state.add_insight("Insight 1")
+        state.update_hypothesis("Hypothesis 1")
+        state.add_discovery({"title": "Discovery 1"})
+
+        # Should not raise
+        json_data = state.model_dump(mode="json")
+        json_str = json.dumps(json_data, default=str)
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert parsed["session_id"] == "sess-123"
+        assert "Insight 1" in parsed["key_insights"]
+
+    def test_session_state_round_trip(self):
+        """Test SessionState survives JSON round-trip."""
+        original = SessionState(
+            session_id="sess-123",
+            objective="Test objective",
+        )
+        original.add_insight("Insight 1")
+        original.update_hypothesis("Hypothesis 1")
+
+        # Serialize and deserialize
+        json_data = original.model_dump(mode="json")
+        json_str = json.dumps(json_data, default=str)
+        parsed = json.loads(json_str)
+
+        # Handle datetime fields
+        if "created_at" in parsed and isinstance(parsed["created_at"], str):
+            parsed["created_at"] = datetime.fromisoformat(
+                parsed["created_at"].replace("Z", "+00:00")
+            )
+        if "updated_at" in parsed and isinstance(parsed["updated_at"], str):
+            parsed["updated_at"] = datetime.fromisoformat(
+                parsed["updated_at"].replace("Z", "+00:00")
+            )
+
+        restored = SessionState(**parsed)
+
+        assert restored.session_id == original.session_id
+        assert restored.objective == original.objective
+        assert restored.key_insights == original.key_insights
+        assert restored.current_hypothesis == original.current_hypothesis


### PR DESCRIPTION
## Overview
Implements two-tier state management inspired by BioAgents, separating transient request state from persistent session state for multi-turn research workflows.

## Architecture
| Tier | Class | Lifecycle | Persistence |
|------|-------|-----------|-------------|
| 1 | `RequestState` | Per-request | Transient (never persisted) |
| 2 | `SessionState` | Per-session | `.session_state.json` |

## Key Features
- **StateManager** orchestrates both tiers with thread-safe file I/O
- **RequestState** tracks per-request timing, steps, errors, warnings
- **SessionState** accumulates insights (max 10), hypothesis, methodology
- Convergence detection for iterative research workflows
- Integration with `DataManagerV2`

## Files Added
- `lobster/core/schemas/state.py` (~450 lines) - Complete state system
- `tests/unit/core/test_state.py` - 53 unit tests
- `tests/integration/test_state_lifecycle.py` - 26 integration tests

## Files Modified
- `lobster/core/schemas/__init__.py` - Added exports
- `lobster/core/data_manager_v2.py` - Integrated StateManager (~170 lines)

## Testing
- ✅ 79 tests passing (53 unit + 26 integration)
- ✅ Live testing with multi-step workflows working
- ✅ File persistence verified (`.session_state.json` created correctly)

## Implementation Notes
- Follows BioAgents IMPL_PLAN_02 specification
- **NO backward compatibility** (breaking change)
- Thread-safe with `threading.Lock` for file I/O
- Session cache for performance

## Related
Part of BioAgents feature integration (3/3 features).