### PR TITLE
feat: Add unified vector search pipeline for literature and ontology

### DIFF
--- a/lobster/core/schemas/__init__.py
+++ b/lobster/core/schemas/__init__.py
@@ -8,6 +8,17 @@ and flexible validation that supports both strict and permissive modes.
 from .download_queue import DownloadQueueEntry, DownloadStatus, StrategyConfig
 from .ontology import DiseaseConcept, DiseaseMatch, DiseaseOntologyConfig
 
+# Vector search schemas
+from .search import (
+    SearchBackend,
+    EmbeddingProvider,
+    SearchResult,
+    SearchResponse,
+    OntologyMatch,
+    LiteratureMatch,
+    VectorSearchConfig,
+)
+
 # Clinical trial metadata (RECIST 1.1, timepoints)
 from .clinical_schema import (
     RECIST_RESPONSES,
@@ -30,6 +41,14 @@ __all__ = [
     "DiseaseConcept",
     "DiseaseMatch",
     "DiseaseOntologyConfig",
+    # Vector search schemas
+    "SearchBackend",
+    "EmbeddingProvider",
+    "SearchResult",
+    "SearchResponse",
+    "OntologyMatch",
+    "LiteratureMatch",
+    "VectorSearchConfig",
     # Clinical schema exports
     "RECIST_RESPONSES",
     "RESPONDER_GROUP",

--- a/lobster/core/schemas/search.py
+++ b/lobster/core/schemas/search.py
@@ -1,0 +1,143 @@
+"""
+Vector Search Schema Definitions
+
+Unified schemas for vector search operations supporting both
+literature search and ontology standardization use cases.
+
+Design follows BioAgents pattern with two-stage pipeline:
+1. Vector search (broad, fast)
+2. Reranking (precise, optional)
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SearchBackend(str, Enum):
+    """Available vector search backends."""
+
+    CHROMA = "chroma"  # ChromaDB (ontology, persistent)
+    FAISS = "faiss"  # FAISS (literature, ephemeral)
+    PGVECTOR = "pgvector"  # PostgreSQL (cloud, future)
+
+
+class EmbeddingProvider(str, Enum):
+    """Available embedding providers."""
+
+    SENTENCE_TRANSFORMERS = "sentence_transformers"  # Local, free, 384 dims
+    OPENAI = "openai"  # API, paid, 1536 dims
+
+
+class SearchResult(BaseModel):
+    """
+    Single search result from vector search.
+
+    Attributes:
+        id: Unique identifier for the document
+        content: Full text content of the document
+        metadata: Additional metadata (source, ontology_id, etc.)
+        similarity_score: Cosine similarity from vector search (0.0-1.0)
+        relevance_score: Reranker score, only present if reranking enabled
+    """
+
+    id: str
+    content: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    similarity_score: float = Field(ge=0.0, le=1.0)
+    relevance_score: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Reranker score (only if reranking enabled)",
+    )
+
+
+class SearchResponse(BaseModel):
+    """
+    Complete search response with results and metadata.
+
+    Provides transparency about the search pipeline configuration
+    and performance metrics for debugging and optimization.
+    """
+
+    query: str
+    results: List[SearchResult]
+    backend: SearchBackend
+    embedding_provider: EmbeddingProvider
+    reranking_applied: bool = False
+    total_candidates: int  # Before reranking
+    search_time_ms: int
+    rerank_time_ms: Optional[int] = None
+
+
+class OntologyMatch(BaseModel):
+    """
+    Ontology matching result.
+
+    Compatible with existing DiseaseOntologyService API.
+    Enables seamless Phase 1 (keyword) to Phase 2 (embedding) migration.
+
+    Attributes:
+        input_term: Original query term from user
+        matched_term: Canonical term from ontology
+        ontology_id: Formal ontology identifier (e.g., "MONDO:0005575")
+        ontology_source: Ontology name (e.g., "MONDO", "UBERON", "CL")
+        confidence: Match confidence (0.0-1.0)
+        synonyms: Known synonyms for the matched term
+        definition: Ontology definition text
+    """
+
+    input_term: str
+    matched_term: str
+    ontology_id: str
+    ontology_source: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    synonyms: List[str] = Field(default_factory=list)
+    definition: Optional[str] = None
+
+
+class LiteratureMatch(BaseModel):
+    """
+    Literature search result.
+
+    Designed for research_agent semantic search over cached abstracts.
+
+    Attributes:
+        query: Original search query
+        title: Publication title
+        abstract: Publication abstract text
+        doi: Digital Object Identifier (optional)
+        pmid: PubMed ID (optional)
+        relevance_score: Combined similarity/reranking score
+        matched_terms: Terms that contributed to the match
+    """
+
+    query: str
+    title: str
+    abstract: Optional[str] = None
+    doi: Optional[str] = None
+    pmid: Optional[str] = None
+    relevance_score: float = Field(ge=0.0, le=1.0)
+    matched_terms: List[str] = Field(default_factory=list)
+
+
+class VectorSearchConfig(BaseModel):
+    """
+    Configuration for vector search service.
+
+    Environment variable mapping:
+    - embedding_provider: LOBSTER_EMBEDDING_PROVIDER
+    - enable_reranking: LOBSTER_ENABLE_RERANKING
+    - ontology_cache_dir: LOBSTER_ONTOLOGY_CACHE_DIR
+    """
+
+    embedding_provider: EmbeddingProvider = EmbeddingProvider.SENTENCE_TRANSFORMERS
+    enable_reranking: bool = True
+    vector_search_limit: int = Field(default=20, ge=1, le=100)
+    final_result_limit: int = Field(default=5, ge=1, le=50)
+    similarity_threshold: float = Field(default=0.3, ge=0.0, le=1.0)
+    reranker_threshold: float = Field(default=0.0, ge=0.0, le=1.0)
+    cache_ttl_seconds: int = Field(default=300, ge=0)  # 5 minutes
+    ontology_cache_dir: str = "~/.lobster/ontology_cache"

--- a/lobster/services/search/__init__.py
+++ b/lobster/services/search/__init__.py
@@ -1,0 +1,23 @@
+"""
+Vector Search Service Module
+
+Unified vector search infrastructure for Lobster AI.
+Supports both literature search and ontology standardization.
+
+Usage:
+    from lobster.services.search import VectorSearchService
+    from lobster.services.search.backends import ChromaBackend, FAISSBackend
+    from lobster.services.search.embeddings import (
+        SentenceTransformersProvider,
+        OpenAIEmbeddingProvider,
+    )
+
+Dependencies (optional):
+    pip install lobster-ai[search]
+"""
+
+from lobster.services.search.vector_search_service import VectorSearchService
+
+__all__ = [
+    "VectorSearchService",
+]

--- a/lobster/services/search/backends/__init__.py
+++ b/lobster/services/search/backends/__init__.py
@@ -1,0 +1,20 @@
+"""
+Vector Search Backends
+
+Pluggable backend implementations for different storage strategies:
+- ChromaBackend: Persistent storage for ontology embeddings (lazy download)
+- FAISSBackend: In-memory ephemeral storage for literature search
+
+Usage:
+    from lobster.services.search.backends import ChromaBackend, FAISSBackend
+"""
+
+from lobster.services.search.backends.base import BaseVectorBackend
+from lobster.services.search.backends.chroma_backend import ChromaBackend
+from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+__all__ = [
+    "BaseVectorBackend",
+    "ChromaBackend",
+    "FAISSBackend",
+]

--- a/lobster/services/search/backends/base.py
+++ b/lobster/services/search/backends/base.py
@@ -1,0 +1,114 @@
+"""
+Abstract Vector Search Backend
+
+Base class for all vector search backends.
+Provides a unified interface for different storage solutions.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+
+class BaseVectorBackend(ABC):
+    """
+    Abstract base class for vector search backends.
+
+    All backends must implement:
+    - add_documents: Add documents with embeddings
+    - search: Find similar documents
+    - delete: Remove documents
+    - count: Return document count
+
+    Implementations:
+    - ChromaBackend: Persistent storage for ontology (lazy download)
+    - FAISSBackend: In-memory ephemeral storage for literature
+    - PgVectorBackend: PostgreSQL for cloud deployment (future)
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return backend name for logging and debugging."""
+        pass
+
+    @abstractmethod
+    def add_documents(
+        self,
+        ids: List[str],
+        embeddings: List[np.ndarray],
+        texts: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """
+        Add documents to the index.
+
+        Args:
+            ids: Unique identifiers for each document
+            embeddings: Pre-computed embedding vectors
+            texts: Document content
+            metadatas: Optional metadata for each document
+
+        Raises:
+            ValueError: If list lengths don't match
+        """
+        pass
+
+    @abstractmethod
+    def search(
+        self,
+        query_embedding: np.ndarray,
+        k: int = 10,
+        filter_metadata: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search for similar documents.
+
+        Args:
+            query_embedding: Query vector
+            k: Number of results to return
+            filter_metadata: Optional metadata filter
+
+        Returns:
+            List of dicts with keys:
+            - id: str
+            - content: str
+            - metadata: dict
+            - similarity_score: float (0.0-1.0)
+        """
+        pass
+
+    @abstractmethod
+    def delete(self, ids: List[str]) -> None:
+        """
+        Delete documents by ID.
+
+        Args:
+            ids: List of document IDs to delete
+        """
+        pass
+
+    @abstractmethod
+    def count(self) -> int:
+        """
+        Return total document count.
+
+        Returns:
+            Number of documents in the index
+        """
+        pass
+
+    def clear(self) -> None:
+        """
+        Clear all documents from the index.
+
+        Default implementation deletes all documents.
+        Subclasses may override for efficiency.
+        """
+        # Default: no-op (subclasses should override)
+        pass
+
+    def __repr__(self) -> str:
+        """String representation for debugging."""
+        return f"{self.__class__.__name__}(count={self.count()})"

--- a/lobster/services/search/backends/chroma_backend.py
+++ b/lobster/services/search/backends/chroma_backend.py
@@ -1,0 +1,276 @@
+"""
+ChromaDB Backend for Ontology Search
+
+Persistent storage for pre-built ontology embeddings.
+Supports lazy download from GitHub releases following BioAgents pattern.
+
+Key Features:
+- Persistent storage (~/.lobster/ontology_cache/)
+- Lazy download from GitHub releases
+- Pre-built embeddings (no runtime embedding cost)
+- Supports multiple ontologies (MONDO, UBERON, CL, NCBI)
+"""
+
+import logging
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from lobster.services.search.backends.base import BaseVectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class ChromaBackend(BaseVectorBackend):
+    """
+    ChromaDB persistent vector store.
+
+    Used for:
+    - Disease ontology (MONDO)
+    - Tissue ontology (UBERON)
+    - Cell type ontology (CL)
+    - Organism taxonomy (NCBI)
+
+    Features:
+    - Persistent storage (~/.lobster/ontology_cache/)
+    - Lazy download from GitHub releases
+    - Pre-built embeddings (no runtime embedding cost)
+
+    Usage:
+        # Load ontology collection (auto-downloads if needed)
+        backend = ChromaBackend("mondo")
+        results = backend.search(query_embedding, k=5)
+
+        # Custom cache directory
+        backend = ChromaBackend("uberon", cache_dir="/custom/path")
+    """
+
+    DEFAULT_CACHE_DIR = "~/.lobster/ontology_cache"
+    GITHUB_RELEASE_URL = (
+        "https://github.com/the-omics-os/lobster-ontologies/releases/download"
+    )
+    RELEASE_VERSION = "v1.0.0"
+
+    def __init__(
+        self,
+        collection_name: str,
+        cache_dir: Optional[str] = None,
+        auto_download: bool = True,
+    ):
+        """
+        Initialize ChromaDB backend.
+
+        Args:
+            collection_name: Name of the collection (e.g., "mondo", "uberon")
+            cache_dir: Directory for persistent storage
+                      Defaults to ~/.lobster/ontology_cache
+            auto_download: Whether to auto-download missing collections
+                          Set to False for tests or offline mode
+        """
+        self.collection_name = collection_name
+        self.cache_dir = Path(cache_dir or self.DEFAULT_CACHE_DIR).expanduser()
+        self.auto_download = auto_download
+        self._client = None
+        self._collection = None
+
+        logger.debug(
+            f"ChromaBackend initialized: collection={collection_name}, "
+            f"cache_dir={self.cache_dir}"
+        )
+
+    @property
+    def name(self) -> str:
+        """Return backend name."""
+        return f"chroma:{self.collection_name}"
+
+    def _ensure_downloaded(self) -> None:
+        """
+        Download pre-built ChromaDB if not present.
+
+        Follows BioAgents lazy download pattern.
+        """
+        collection_path = self.cache_dir / self.collection_name
+
+        if collection_path.exists():
+            logger.debug(f"Collection exists at {collection_path}")
+            return
+
+        if not self.auto_download:
+            raise FileNotFoundError(
+                f"Ontology collection '{self.collection_name}' not found at "
+                f"{collection_path}. Set auto_download=True or manually download."
+            )
+
+        logger.info(f"Downloading ontology collection: {self.collection_name}")
+        self._download_collection()
+
+    def _download_collection(self) -> None:
+        """
+        Download and extract collection from GitHub releases.
+
+        Downloads tarball, extracts to cache directory.
+        """
+        url = (
+            f"{self.GITHUB_RELEASE_URL}/{self.RELEASE_VERSION}/"
+            f"{self.collection_name}_chroma.tar.gz"
+        )
+
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+            logger.info(f"Downloading from {url}")
+            try:
+                urllib.request.urlretrieve(url, tmp.name)
+
+                logger.info(f"Extracting to {self.cache_dir}")
+                with tarfile.open(tmp.name, "r:gz") as tar:
+                    tar.extractall(self.cache_dir)
+
+                logger.info(f"Downloaded {self.collection_name} ontology")
+            except Exception as e:
+                logger.error(f"Failed to download {self.collection_name}: {e}")
+                raise
+
+    def _get_collection(self):
+        """
+        Lazy load ChromaDB collection.
+
+        Returns:
+            chromadb Collection object
+        """
+        if self._collection is not None:
+            return self._collection
+
+        self._ensure_downloaded()
+
+        try:
+            import chromadb
+
+            persist_path = str(self.cache_dir / self.collection_name)
+            self._client = chromadb.PersistentClient(path=persist_path)
+
+            # Get or create collection
+            try:
+                self._collection = self._client.get_collection(self.collection_name)
+            except Exception:
+                # Collection might not exist yet (for tests)
+                self._collection = self._client.get_or_create_collection(
+                    name=self.collection_name,
+                    metadata={"hnsw:space": "cosine"},
+                )
+
+            logger.info(
+                f"Loaded ChromaDB collection: {self.collection_name} "
+                f"({self._collection.count()} documents)"
+            )
+            return self._collection
+
+        except ImportError as e:
+            raise ImportError(
+                "chromadb not installed. Install with: pip install lobster-ai[search]"
+            ) from e
+
+    def add_documents(
+        self,
+        ids: List[str],
+        embeddings: List[np.ndarray],
+        texts: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """
+        Add documents to ChromaDB collection.
+
+        Args:
+            ids: Unique identifiers for each document
+            embeddings: Pre-computed embedding vectors
+            texts: Document content
+            metadatas: Optional metadata for each document
+        """
+        if len(ids) != len(embeddings) or len(ids) != len(texts):
+            raise ValueError("ids, embeddings, and texts must have same length")
+
+        collection = self._get_collection()
+        collection.add(
+            ids=ids,
+            embeddings=[e.tolist() for e in embeddings],
+            documents=texts,
+            metadatas=metadatas,
+        )
+        logger.debug(f"Added {len(ids)} documents to {self.collection_name}")
+
+    def search(
+        self,
+        query_embedding: np.ndarray,
+        k: int = 10,
+        filter_metadata: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search for similar documents.
+
+        Args:
+            query_embedding: Query vector
+            k: Number of results to return
+            filter_metadata: Optional metadata filter (ChromaDB where clause)
+
+        Returns:
+            List of dicts with id, content, metadata, similarity_score
+        """
+        collection = self._get_collection()
+
+        results = collection.query(
+            query_embeddings=[query_embedding.tolist()],
+            n_results=k,
+            where=filter_metadata,
+        )
+
+        # Format results
+        formatted = []
+        if results["ids"] and results["ids"][0]:
+            for i, doc_id in enumerate(results["ids"][0]):
+                # ChromaDB returns distances, convert to similarity
+                distance = results["distances"][0][i] if results["distances"] else 0
+                # For cosine distance: similarity = 1 - distance
+                similarity = max(0.0, min(1.0, 1.0 - distance))
+
+                formatted.append(
+                    {
+                        "id": doc_id,
+                        "content": (
+                            results["documents"][0][i]
+                            if results["documents"]
+                            else ""
+                        ),
+                        "metadata": (
+                            results["metadatas"][0][i]
+                            if results["metadatas"]
+                            else {}
+                        ),
+                        "similarity_score": similarity,
+                    }
+                )
+
+        return formatted
+
+    def delete(self, ids: List[str]) -> None:
+        """Delete documents by ID."""
+        collection = self._get_collection()
+        collection.delete(ids=ids)
+        logger.debug(f"Deleted {len(ids)} documents from {self.collection_name}")
+
+    def count(self) -> int:
+        """Return total document count."""
+        collection = self._get_collection()
+        return collection.count()
+
+    def clear(self) -> None:
+        """Clear all documents from the collection."""
+        collection = self._get_collection()
+        # Get all IDs and delete them
+        all_docs = collection.get()
+        if all_docs["ids"]:
+            collection.delete(ids=all_docs["ids"])
+        logger.debug(f"Cleared collection {self.collection_name}")

--- a/lobster/services/search/backends/faiss_backend.py
+++ b/lobster/services/search/backends/faiss_backend.py
@@ -1,0 +1,276 @@
+"""
+FAISS Backend for Literature Search
+
+In-memory ephemeral storage for literature search.
+Optimized for fast similarity search without persistence.
+
+Key Features:
+- In-memory (fast, no disk I/O)
+- Ephemeral (no persistence between sessions)
+- Efficient for small to medium datasets
+- Supports exact nearest neighbor search
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from lobster.services.search.backends.base import BaseVectorBackend
+
+logger = logging.getLogger(__name__)
+
+
+class FAISSBackend(BaseVectorBackend):
+    """
+    FAISS in-memory vector store.
+
+    Used for:
+    - Literature search (cached abstracts)
+    - Custom document search
+    - Temporary collections
+
+    Features:
+    - In-memory storage (fast)
+    - No persistence (ephemeral)
+    - Efficient cosine similarity
+
+    Usage:
+        backend = FAISSBackend(dimension=384)
+        backend.add_documents(ids, embeddings, texts, metadatas)
+        results = backend.search(query_embedding, k=5)
+    """
+
+    def __init__(self, dimension: int = 384):
+        """
+        Initialize FAISS backend.
+
+        Args:
+            dimension: Embedding vector dimension
+                      Should match the embedding provider dimension
+        """
+        self.dimension = dimension
+        self._index = None
+        self._documents: Dict[str, Dict[str, Any]] = {}  # id -> doc data
+        self._id_to_idx: Dict[str, int] = {}  # id -> faiss index
+        self._idx_to_id: Dict[int, str] = {}  # faiss index -> id
+
+        logger.debug(f"FAISSBackend initialized with dimension={dimension}")
+
+    @property
+    def name(self) -> str:
+        """Return backend name."""
+        return "faiss:memory"
+
+    def _get_index(self):
+        """
+        Lazy initialize FAISS index.
+
+        Uses IndexFlatIP (inner product) with normalized vectors
+        for cosine similarity.
+        """
+        if self._index is None:
+            try:
+                import faiss
+
+                # Use L2 index for simplicity (we normalize vectors for cosine)
+                self._index = faiss.IndexFlatL2(self.dimension)
+                logger.debug(f"Created FAISS index with dimension={self.dimension}")
+            except ImportError as e:
+                raise ImportError(
+                    "faiss-cpu not installed. "
+                    "Install with: pip install lobster-ai[search]"
+                ) from e
+        return self._index
+
+    def _normalize(self, vectors: np.ndarray) -> np.ndarray:
+        """
+        L2 normalize vectors for cosine similarity.
+
+        Args:
+            vectors: Input vectors (N, D) or (D,)
+
+        Returns:
+            Normalized vectors
+        """
+        if vectors.ndim == 1:
+            vectors = vectors.reshape(1, -1)
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        norms = np.where(norms == 0, 1, norms)  # Avoid division by zero
+        return vectors / norms
+
+    def add_documents(
+        self,
+        ids: List[str],
+        embeddings: List[np.ndarray],
+        texts: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """
+        Add documents to FAISS index.
+
+        Args:
+            ids: Unique identifiers for each document
+            embeddings: Pre-computed embedding vectors
+            texts: Document content
+            metadatas: Optional metadata for each document
+
+        Raises:
+            ValueError: If list lengths don't match or dimension mismatch
+        """
+        if len(ids) != len(embeddings) or len(ids) != len(texts):
+            raise ValueError("ids, embeddings, and texts must have same length")
+
+        if metadatas and len(metadatas) != len(ids):
+            raise ValueError("metadatas must have same length as ids")
+
+        index = self._get_index()
+
+        # Convert and validate embeddings
+        vectors = np.array(embeddings, dtype=np.float32)
+        if vectors.shape[1] != self.dimension:
+            raise ValueError(
+                f"Embedding dimension mismatch: got {vectors.shape[1]}, "
+                f"expected {self.dimension}"
+            )
+
+        # Normalize for cosine similarity
+        vectors = self._normalize(vectors)
+
+        # Add to index
+        start_idx = index.ntotal
+        index.add(vectors)
+
+        # Store document data and ID mappings
+        for i, doc_id in enumerate(ids):
+            idx = start_idx + i
+            self._id_to_idx[doc_id] = idx
+            self._idx_to_id[idx] = doc_id
+            self._documents[doc_id] = {
+                "content": texts[i],
+                "metadata": metadatas[i] if metadatas else {},
+            }
+
+        logger.debug(f"Added {len(ids)} documents to FAISS index")
+
+    def search(
+        self,
+        query_embedding: np.ndarray,
+        k: int = 10,
+        filter_metadata: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search for similar documents.
+
+        Args:
+            query_embedding: Query vector
+            k: Number of results to return
+            filter_metadata: Optional metadata filter (post-search filtering)
+
+        Returns:
+            List of dicts with id, content, metadata, similarity_score
+        """
+        index = self._get_index()
+
+        if index.ntotal == 0:
+            return []
+
+        # Normalize query for cosine similarity
+        query = self._normalize(query_embedding.reshape(1, -1).astype(np.float32))
+
+        # Search (request more if we need to filter)
+        search_k = min(k * 3, index.ntotal) if filter_metadata else min(k, index.ntotal)
+        distances, indices = index.search(query, search_k)
+
+        # Format results
+        results = []
+        for i, idx in enumerate(indices[0]):
+            if idx < 0:  # FAISS returns -1 for empty slots
+                continue
+
+            doc_id = self._idx_to_id.get(int(idx))
+            if doc_id is None:
+                continue
+
+            doc = self._documents[doc_id]
+
+            # Apply metadata filter if provided
+            if filter_metadata:
+                match = all(
+                    doc["metadata"].get(key) == value
+                    for key, value in filter_metadata.items()
+                )
+                if not match:
+                    continue
+
+            # Convert L2 distance to similarity score
+            # For normalized vectors: distance = 2 - 2*cos(theta)
+            # So similarity = 1 - distance/2
+            distance = distances[0][i]
+            similarity = max(0.0, min(1.0, 1.0 - distance / 2))
+
+            results.append(
+                {
+                    "id": doc_id,
+                    "content": doc["content"],
+                    "metadata": doc["metadata"],
+                    "similarity_score": similarity,
+                }
+            )
+
+            if len(results) >= k:
+                break
+
+        return results
+
+    def delete(self, ids: List[str]) -> None:
+        """
+        Delete documents by ID.
+
+        Note: FAISS IndexFlatL2 doesn't support deletion.
+        We mark documents as deleted and filter them out on search.
+        For full deletion, rebuild the index.
+        """
+        for doc_id in ids:
+            if doc_id in self._documents:
+                del self._documents[doc_id]
+                idx = self._id_to_idx.pop(doc_id, None)
+                if idx is not None:
+                    self._idx_to_id.pop(idx, None)
+
+        logger.debug(f"Marked {len(ids)} documents as deleted")
+
+    def count(self) -> int:
+        """Return total document count."""
+        return len(self._documents)
+
+    def clear(self) -> None:
+        """Clear all documents and reset index."""
+        self._index = None
+        self._documents.clear()
+        self._id_to_idx.clear()
+        self._idx_to_id.clear()
+        logger.debug("Cleared FAISS index")
+
+    def add_document(
+        self,
+        doc_id: str,
+        text: str,
+        embedding: np.ndarray,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Convenience method to add a single document.
+
+        Args:
+            doc_id: Unique identifier
+            text: Document content
+            embedding: Pre-computed embedding
+            metadata: Optional metadata
+        """
+        self.add_documents(
+            ids=[doc_id],
+            embeddings=[embedding],
+            texts=[text],
+            metadatas=[metadata] if metadata else None,
+        )

--- a/lobster/services/search/embeddings/__init__.py
+++ b/lobster/services/search/embeddings/__init__.py
@@ -1,0 +1,36 @@
+"""
+Embedding Providers
+
+Abstraction over embedding generation with support for:
+- SentenceTransformersProvider: Local, free, no API costs (default)
+- OpenAIEmbeddingProvider: Cloud API, higher quality, paid
+
+Usage:
+    from lobster.services.search.embeddings import (
+        get_embedding_provider,
+        SentenceTransformersProvider,
+        OpenAIEmbeddingProvider,
+    )
+"""
+
+from lobster.services.search.embeddings.base import BaseEmbeddingProvider
+from lobster.services.search.embeddings.sentence_transformers import (
+    SentenceTransformersProvider,
+    get_sentence_transformers_provider,
+)
+
+__all__ = [
+    "BaseEmbeddingProvider",
+    "SentenceTransformersProvider",
+    "get_sentence_transformers_provider",
+]
+
+# Conditional imports for optional providers
+try:
+    from lobster.services.search.embeddings.openai_embeddings import (
+        OpenAIEmbeddingProvider,
+    )
+
+    __all__.append("OpenAIEmbeddingProvider")
+except ImportError:
+    pass  # OpenAI not installed

--- a/lobster/services/search/embeddings/base.py
+++ b/lobster/services/search/embeddings/base.py
@@ -1,0 +1,88 @@
+"""
+Abstract Embedding Provider
+
+Base class for all embedding providers (local and API-based).
+Follows the provider pattern from BioAgents with lazy initialization.
+"""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+import numpy as np
+
+
+class BaseEmbeddingProvider(ABC):
+    """
+    Abstract base class for embedding providers.
+
+    All providers must implement:
+    - model_name: Identifier for the embedding model
+    - embedding_dimension: Vector dimension output
+    - embed_text: Generate embedding for single text
+    - embed_batch: Generate embeddings for multiple texts
+
+    Design Principles:
+    - Lazy initialization: Models loaded on first use
+    - Thread-safe: Can be used across threads
+    - Batch support: Efficient batch embedding generation
+    """
+
+    @property
+    @abstractmethod
+    def model_name(self) -> str:
+        """
+        Return model identifier.
+
+        Examples:
+            - "all-MiniLM-L6-v2" (sentence-transformers)
+            - "text-embedding-3-small" (OpenAI)
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def embedding_dimension(self) -> int:
+        """
+        Return embedding vector dimension.
+
+        Examples:
+            - 384 (all-MiniLM-L6-v2)
+            - 1536 (text-embedding-3-small)
+        """
+        pass
+
+    @abstractmethod
+    def embed_text(self, text: str) -> np.ndarray:
+        """
+        Generate embedding for single text.
+
+        Args:
+            text: Input text to embed
+
+        Returns:
+            numpy array of shape (embedding_dimension,)
+        """
+        pass
+
+    @abstractmethod
+    def embed_batch(self, texts: List[str]) -> List[np.ndarray]:
+        """
+        Generate embeddings for multiple texts.
+
+        More efficient than calling embed_text in a loop.
+        Implementations should handle batching internally.
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of numpy arrays, each of shape (embedding_dimension,)
+        """
+        pass
+
+    def __repr__(self) -> str:
+        """String representation for debugging."""
+        return (
+            f"{self.__class__.__name__}(model={self.model_name}, "
+            f"dim={self.embedding_dimension})"
+        )

--- a/lobster/services/search/embeddings/openai_embeddings.py
+++ b/lobster/services/search/embeddings/openai_embeddings.py
@@ -1,0 +1,163 @@
+"""
+OpenAI API Embedding Provider
+
+Higher quality embeddings, requires API key and incurs costs.
+Model: text-embedding-3-small (1536 dimensions)
+
+Benefits:
+- Higher quality embeddings
+- Better semantic understanding
+- Larger context window
+
+Costs:
+- $0.00002 per 1K tokens
+- Rate limits apply
+- Requires OPENAI_API_KEY environment variable
+"""
+
+import logging
+import os
+from typing import List, Optional
+
+import numpy as np
+
+from lobster.services.search.embeddings.base import BaseEmbeddingProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIEmbeddingProvider(BaseEmbeddingProvider):
+    """
+    OpenAI API embedding provider.
+
+    Lazy loads the client on first use. Requires OPENAI_API_KEY
+    environment variable or explicit api_key parameter.
+
+    Model Options:
+    - text-embedding-3-small: 1536 dims, good balance of quality/cost (default)
+    - text-embedding-3-large: 3072 dims, highest quality
+    - text-embedding-ada-002: 1536 dims, legacy model
+
+    Usage:
+        # With environment variable OPENAI_API_KEY
+        provider = OpenAIEmbeddingProvider()
+        embedding = provider.embed_text("colorectal cancer")
+
+        # With explicit API key
+        provider = OpenAIEmbeddingProvider(api_key="sk-...")
+    """
+
+    # Model registry with dimensions
+    MODEL_DIMENSIONS = {
+        "text-embedding-3-small": 1536,
+        "text-embedding-3-large": 3072,
+        "text-embedding-ada-002": 1536,
+    }
+
+    DEFAULT_MODEL = "text-embedding-3-small"
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        """
+        Initialize provider with model name and API key.
+
+        Client is not created until first use (lazy initialization).
+
+        Args:
+            model_name: OpenAI embedding model name
+                       Defaults to text-embedding-3-small
+            api_key: OpenAI API key. If not provided, uses OPENAI_API_KEY env var
+
+        Raises:
+            ValueError: If no API key provided and OPENAI_API_KEY not set
+        """
+        self._model_name = model_name or self.DEFAULT_MODEL
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self._client = None  # Lazy load
+        self._dimension = self.MODEL_DIMENSIONS.get(self._model_name, 1536)
+
+        if not self._api_key:
+            raise ValueError(
+                "OPENAI_API_KEY environment variable not set. "
+                "Either set the environment variable or pass api_key parameter."
+            )
+
+        logger.debug(
+            f"OpenAIEmbeddingProvider initialized with model={self._model_name} "
+            f"(dimension={self._dimension})"
+        )
+
+    @property
+    def model_name(self) -> str:
+        """Return model identifier."""
+        return self._model_name
+
+    @property
+    def embedding_dimension(self) -> int:
+        """Return embedding vector dimension."""
+        return self._dimension
+
+    def _get_client(self):
+        """
+        Lazy load OpenAI client on first use.
+
+        This avoids importing openai at module level, which would
+        require the package to be installed even when not used.
+        """
+        if self._client is None:
+            logger.info(f"Initializing OpenAI client for model: {self._model_name}")
+            try:
+                from openai import OpenAI
+
+                self._client = OpenAI(api_key=self._api_key)
+                logger.info("OpenAI client initialized successfully")
+            except ImportError as e:
+                raise ImportError(
+                    "openai package not installed. "
+                    "Install with: pip install lobster-ai[search]"
+                ) from e
+        return self._client
+
+    def embed_text(self, text: str) -> np.ndarray:
+        """
+        Generate embedding for single text.
+
+        Args:
+            text: Input text to embed
+
+        Returns:
+            numpy array of shape (embedding_dimension,)
+        """
+        client = self._get_client()
+        response = client.embeddings.create(
+            model=self._model_name,
+            input=text,
+            encoding_format="float",
+        )
+        return np.array(response.data[0].embedding)
+
+    def embed_batch(self, texts: List[str]) -> List[np.ndarray]:
+        """
+        Generate embeddings for multiple texts.
+
+        OpenAI API supports batch requests natively.
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of numpy arrays, each of shape (embedding_dimension,)
+        """
+        if not texts:
+            return []
+
+        client = self._get_client()
+        response = client.embeddings.create(
+            model=self._model_name,
+            input=texts,
+            encoding_format="float",
+        )
+        return [np.array(item.embedding) for item in response.data]

--- a/lobster/services/search/embeddings/sentence_transformers.py
+++ b/lobster/services/search/embeddings/sentence_transformers.py
@@ -1,0 +1,166 @@
+"""
+Local Sentence Transformers Embedding Provider
+
+Free, fast (10x faster than API), no token costs.
+Default model: all-MiniLM-L6-v2 (384 dimensions)
+
+Benefits:
+- No API costs
+- No rate limits
+- Privacy-preserving (data stays local)
+- 10x faster than API calls
+- Works offline
+"""
+
+import logging
+from functools import lru_cache
+from typing import List, Optional
+
+import numpy as np
+
+from lobster.services.search.embeddings.base import BaseEmbeddingProvider
+
+logger = logging.getLogger(__name__)
+
+
+class SentenceTransformersProvider(BaseEmbeddingProvider):
+    """
+    Local embedding provider using sentence-transformers.
+
+    Lazy loads the model on first use to minimize startup time.
+    Thread-safe and can be shared across multiple search services.
+
+    Model Options:
+    - all-MiniLM-L6-v2: 384 dims, fast, good quality (default)
+    - all-mpnet-base-v2: 768 dims, slower, higher quality
+    - paraphrase-MiniLM-L6-v2: 384 dims, good for paraphrase detection
+
+    Usage:
+        provider = SentenceTransformersProvider()
+        embedding = provider.embed_text("colorectal cancer")
+
+        # Or batch processing
+        embeddings = provider.embed_batch(["cancer", "tumor", "neoplasm"])
+    """
+
+    # Model registry with dimensions
+    MODEL_DIMENSIONS = {
+        "all-MiniLM-L6-v2": 384,
+        "all-mpnet-base-v2": 768,
+        "paraphrase-MiniLM-L6-v2": 384,
+        "multi-qa-MiniLM-L6-cos-v1": 384,
+    }
+
+    DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+    def __init__(self, model_name: Optional[str] = None):
+        """
+        Initialize provider with model name.
+
+        Model is not loaded until first use (lazy initialization).
+
+        Args:
+            model_name: sentence-transformers model name
+                       Defaults to all-MiniLM-L6-v2
+        """
+        self._model_name = model_name or self.DEFAULT_MODEL
+        self._model = None  # Lazy load
+        self._dimension = self.MODEL_DIMENSIONS.get(self._model_name, 384)
+
+        logger.debug(
+            f"SentenceTransformersProvider initialized with model={self._model_name} "
+            f"(dimension={self._dimension})"
+        )
+
+    @property
+    def model_name(self) -> str:
+        """Return model identifier."""
+        return self._model_name
+
+    @property
+    def embedding_dimension(self) -> int:
+        """Return embedding vector dimension."""
+        return self._dimension
+
+    def _get_model(self):
+        """
+        Lazy load model on first use.
+
+        This avoids loading the model at import time, which would slow
+        down CLI startup even when vector search is not used.
+        """
+        if self._model is None:
+            logger.info(f"Loading sentence-transformers model: {self._model_name}")
+            try:
+                from sentence_transformers import SentenceTransformer
+
+                self._model = SentenceTransformer(self._model_name)
+                # Update dimension from actual model
+                self._dimension = self._model.get_sentence_embedding_dimension()
+                logger.info(
+                    f"Model loaded successfully (dimension={self._dimension})"
+                )
+            except ImportError as e:
+                raise ImportError(
+                    "sentence-transformers not installed. "
+                    "Install with: pip install lobster-ai[search]"
+                ) from e
+        return self._model
+
+    def embed_text(self, text: str) -> np.ndarray:
+        """
+        Generate embedding for single text.
+
+        Args:
+            text: Input text to embed
+
+        Returns:
+            numpy array of shape (embedding_dimension,)
+        """
+        model = self._get_model()
+        embedding = model.encode(text, convert_to_numpy=True, show_progress_bar=False)
+        return embedding
+
+    def embed_batch(self, texts: List[str]) -> List[np.ndarray]:
+        """
+        Generate embeddings for multiple texts.
+
+        Uses internal batching for efficiency.
+        Progress bar disabled for cleaner output.
+
+        Args:
+            texts: List of texts to embed
+
+        Returns:
+            List of numpy arrays, each of shape (embedding_dimension,)
+        """
+        if not texts:
+            return []
+
+        model = self._get_model()
+        embeddings = model.encode(
+            texts,
+            convert_to_numpy=True,
+            batch_size=32,
+            show_progress_bar=False,
+        )
+        return list(embeddings)
+
+
+@lru_cache(maxsize=4)
+def get_sentence_transformers_provider(
+    model_name: Optional[str] = None,
+) -> SentenceTransformersProvider:
+    """
+    Get singleton instance of sentence transformers provider.
+
+    Cached per model_name to avoid loading multiple instances of
+    the same model.
+
+    Args:
+        model_name: Model to use (defaults to all-MiniLM-L6-v2)
+
+    Returns:
+        Cached SentenceTransformersProvider instance
+    """
+    return SentenceTransformersProvider(model_name)

--- a/lobster/services/search/reranker.py
+++ b/lobster/services/search/reranker.py
@@ -1,0 +1,217 @@
+"""
+Cohere Reranker for Two-Stage Search
+
+Improves search precision by reranking initial vector search results.
+Follows BioAgents pattern: vector search (20) -> rerank (top 5).
+
+Key Features:
+- Graceful degradation (works without COHERE_API_KEY)
+- Configurable thresholds
+- Supports various document formats
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CohereReranker:
+    """
+    Cohere reranking for improved search precision.
+
+    Two-stage pipeline:
+    1. Vector search returns 20+ candidates
+    2. Reranker scores each candidate against query
+    3. Return top-k by relevance score
+
+    Model: rerank-english-v3.0
+
+    Usage:
+        # With COHERE_API_KEY environment variable
+        reranker = CohereReranker()
+
+        if reranker.available:
+            reranked = reranker.rerank(
+                query="colorectal cancer treatment",
+                documents=vector_results,
+                top_k=5
+            )
+
+        # Graceful degradation without API key
+        else:
+            print("Reranking unavailable, using vector search order")
+    """
+
+    DEFAULT_MODEL = "rerank-english-v3.0"
+
+    # Alternative models
+    AVAILABLE_MODELS = {
+        "rerank-english-v3.0": "English, highest quality",
+        "rerank-multilingual-v3.0": "Multilingual support",
+        "rerank-english-v2.0": "English, legacy",
+    }
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+    ):
+        """
+        Initialize Cohere reranker.
+
+        Args:
+            api_key: Cohere API key. If not provided, uses COHERE_API_KEY env var
+            model: Reranking model. Defaults to rerank-english-v3.0
+        """
+        self._api_key = api_key or os.environ.get("COHERE_API_KEY")
+        self._model = model or self.DEFAULT_MODEL
+        self._client = None
+
+        if not self._api_key:
+            logger.warning(
+                "COHERE_API_KEY not set. Reranking will be disabled. "
+                "Set the environment variable to enable reranking."
+            )
+        else:
+            logger.debug(f"CohereReranker initialized with model={self._model}")
+
+    @property
+    def available(self) -> bool:
+        """
+        Check if reranking is available.
+
+        Returns:
+            True if COHERE_API_KEY is set, False otherwise
+        """
+        return self._api_key is not None
+
+    @property
+    def model(self) -> str:
+        """Return the reranking model name."""
+        return self._model
+
+    def _get_client(self):
+        """
+        Lazy load Cohere client.
+
+        Returns:
+            cohere.Client instance
+        """
+        if self._client is None:
+            if not self._api_key:
+                raise ValueError(
+                    "Cannot create Cohere client without API key. "
+                    "Set COHERE_API_KEY environment variable."
+                )
+            try:
+                import cohere
+
+                self._client = cohere.Client(self._api_key)
+                logger.debug("Cohere client initialized successfully")
+            except ImportError as e:
+                raise ImportError(
+                    "cohere package not installed. "
+                    "Install with: pip install lobster-ai[search]"
+                ) from e
+        return self._client
+
+    def rerank(
+        self,
+        query: str,
+        documents: List[Dict[str, Any]],
+        top_k: int = 5,
+        min_relevance: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        """
+        Rerank documents by relevance to query.
+
+        Args:
+            query: Search query
+            documents: List of documents (must have 'content' key)
+            top_k: Number of results to return
+            min_relevance: Minimum relevance score threshold (0.0-1.0)
+
+        Returns:
+            Reranked documents with added 'relevance_score' key
+
+        Note:
+            Returns original order if reranking is unavailable
+        """
+        if not self.available:
+            logger.warning("Reranking unavailable, returning original order")
+            return documents[:top_k]
+
+        if not documents:
+            return []
+
+        if len(documents) == 1:
+            # No need to rerank single document
+            doc = documents[0].copy()
+            doc["relevance_score"] = 1.0
+            return [doc]
+
+        client = self._get_client()
+
+        # Prepare texts for reranking
+        texts = []
+        for doc in documents:
+            content = doc.get("content", "")
+            # Include title if available
+            title = doc.get("metadata", {}).get("title", "")
+            if title:
+                text = f"{title}\n{content}"
+            else:
+                text = content
+            texts.append(text)
+
+        try:
+            response = client.rerank(
+                model=self._model,
+                query=query,
+                documents=texts,
+                top_n=min(top_k, len(documents)),
+                return_documents=False,  # We have original docs
+            )
+
+            # Map results back to original documents
+            reranked = []
+            for result in response.results:
+                if result.relevance_score >= min_relevance:
+                    doc = documents[result.index].copy()
+                    doc["relevance_score"] = result.relevance_score
+                    reranked.append(doc)
+
+            logger.debug(
+                f"Reranked {len(documents)} documents, "
+                f"returned {len(reranked)} above threshold {min_relevance}"
+            )
+
+            return reranked
+
+        except Exception as e:
+            logger.error(f"Reranking failed: {e}. Returning original order.")
+            return documents[:top_k]
+
+    def rerank_texts(
+        self,
+        query: str,
+        texts: List[str],
+        top_k: int = 5,
+        min_relevance: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        """
+        Convenience method to rerank plain texts.
+
+        Args:
+            query: Search query
+            texts: List of text strings
+            top_k: Number of results to return
+            min_relevance: Minimum relevance score threshold
+
+        Returns:
+            List of dicts with 'content' and 'relevance_score' keys
+        """
+        documents = [{"content": text} for text in texts]
+        return self.rerank(query, documents, top_k, min_relevance)

--- a/lobster/services/search/vector_search_service.py
+++ b/lobster/services/search/vector_search_service.py
@@ -1,0 +1,483 @@
+"""
+Unified Vector Search Service
+
+Serves both literature search and ontology standardization.
+Implements BioAgents two-stage pipeline: vector search -> reranking.
+
+Key Features:
+- Pluggable backends (ChromaDB, FAISS)
+- Embedding provider abstraction (local or API)
+- Optional Cohere reranking
+- 5-minute result caching
+- Compatible with DiseaseOntologyService API
+"""
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from lobster.core.analysis_ir import AnalysisStep
+from lobster.core.schemas.search import (
+    EmbeddingProvider,
+    LiteratureMatch,
+    OntologyMatch,
+    SearchBackend,
+    SearchResponse,
+    SearchResult,
+)
+from lobster.services.search.backends.base import BaseVectorBackend
+from lobster.services.search.backends.chroma_backend import ChromaBackend
+from lobster.services.search.embeddings.base import BaseEmbeddingProvider
+from lobster.services.search.embeddings.sentence_transformers import (
+    get_sentence_transformers_provider,
+)
+from lobster.services.search.reranker import CohereReranker
+
+logger = logging.getLogger(__name__)
+
+
+class VectorSearchService:
+    """
+    Unified vector search service.
+
+    Use Cases:
+    1. Ontology matching (disease, tissue, cell type, organism)
+    2. Literature search (abstracts, methods sections)
+    3. Custom document search (uploaded files)
+
+    Features:
+    - Pluggable backends (ChromaDB, FAISS, pgvector)
+    - Embedding provider abstraction (local or API)
+    - Optional Cohere reranking
+    - Caching for repeated queries
+
+    Usage:
+        # Basic search
+        service = VectorSearchService()
+        response = service.search("colorectal cancer", backend=my_backend)
+
+        # Ontology matching (compatible with DiseaseOntologyService)
+        matches = service.match_ontology("colorectal cancer", ontology="mondo")
+
+        # Literature search
+        matches = service.search_literature("single-cell RNA-seq", backend=my_backend)
+    """
+
+    DEFAULT_VECTOR_LIMIT = 20
+    DEFAULT_FINAL_LIMIT = 5
+    CACHE_TTL_SECONDS = 300  # 5 minutes
+
+    # Ontology collection mapping
+    ONTOLOGY_COLLECTIONS = {
+        "mondo": "mondo",
+        "disease": "mondo",
+        "uberon": "uberon",
+        "tissue": "uberon",
+        "cl": "cell_ontology",
+        "cell_type": "cell_ontology",
+        "cell_ontology": "cell_ontology",
+        "ncbi_taxonomy": "ncbi_taxonomy",
+        "organism": "ncbi_taxonomy",
+        "taxonomy": "ncbi_taxonomy",
+    }
+
+    def __init__(
+        self,
+        backend: Optional[BaseVectorBackend] = None,
+        embedding_provider: Optional[BaseEmbeddingProvider] = None,
+        reranker: Optional[CohereReranker] = None,
+        enable_reranking: bool = True,
+    ):
+        """
+        Initialize VectorSearchService.
+
+        Args:
+            backend: Default vector backend (optional)
+            embedding_provider: Embedding provider (defaults to sentence-transformers)
+            reranker: Cohere reranker (defaults to new instance)
+            enable_reranking: Whether to enable reranking (default True)
+        """
+        self._backend = backend
+        self._embedding_provider = (
+            embedding_provider or get_sentence_transformers_provider()
+        )
+        self._reranker = reranker or CohereReranker()
+        self._enable_reranking = enable_reranking and self._reranker.available
+        self._cache: Dict[str, Tuple[float, Any]] = {}
+        self._ontology_backends: Dict[str, ChromaBackend] = {}
+
+        logger.info(
+            f"VectorSearchService initialized: "
+            f"embedding_provider={self._embedding_provider.model_name}, "
+            f"reranking={'enabled' if self._enable_reranking else 'disabled'}"
+        )
+
+    @property
+    def embedding_provider(self) -> BaseEmbeddingProvider:
+        """Return the embedding provider."""
+        return self._embedding_provider
+
+    @property
+    def reranking_enabled(self) -> bool:
+        """Return whether reranking is enabled."""
+        return self._enable_reranking
+
+    # =========================================================================
+    # GENERIC SEARCH
+    # =========================================================================
+
+    def search(
+        self,
+        query: str,
+        backend: Optional[BaseVectorBackend] = None,
+        vector_limit: Optional[int] = None,
+        final_limit: Optional[int] = None,
+        use_reranking: Optional[bool] = None,
+        filter_metadata: Optional[Dict[str, Any]] = None,
+    ) -> SearchResponse:
+        """
+        Two-stage vector search with optional reranking.
+
+        Stage 1: Vector similarity search (fast, broad)
+        Stage 2: Cohere reranking (precise, slower)
+
+        Args:
+            query: Search query text
+            backend: Vector backend to use (default: self._backend)
+            vector_limit: Initial vector search results (default: 20)
+            final_limit: Final results after reranking (default: 5)
+            use_reranking: Enable reranking (default: self._enable_reranking)
+            filter_metadata: Optional metadata filter for vector search
+
+        Returns:
+            SearchResponse with results and metadata
+
+        Raises:
+            ValueError: If no backend configured
+        """
+        vector_limit = vector_limit or self.DEFAULT_VECTOR_LIMIT
+        final_limit = final_limit or self.DEFAULT_FINAL_LIMIT
+        use_reranking = (
+            use_reranking if use_reranking is not None else self._enable_reranking
+        )
+        backend = backend or self._backend
+
+        if backend is None:
+            raise ValueError(
+                "No backend configured for search. "
+                "Pass a backend parameter or set self._backend"
+            )
+
+        # Check cache
+        cache_key = self._make_cache_key(
+            query, vector_limit, final_limit, use_reranking, backend.name
+        )
+        cached = self._get_cached(cache_key)
+        if cached:
+            logger.debug(f"Cache hit for query: {query[:50]}...")
+            return cached
+
+        start_time = time.time()
+
+        # Stage 1: Vector search
+        query_embedding = self._embedding_provider.embed_text(query)
+        vector_results = backend.search(
+            query_embedding=query_embedding,
+            k=vector_limit,
+            filter_metadata=filter_metadata,
+        )
+
+        search_time_ms = int((time.time() - start_time) * 1000)
+        total_candidates = len(vector_results)
+
+        # Stage 2: Reranking (optional)
+        rerank_time_ms = None
+        reranking_applied = False
+        if use_reranking and len(vector_results) > 1 and self._reranker.available:
+            rerank_start = time.time()
+            reranked = self._reranker.rerank(
+                query=query,
+                documents=vector_results,
+                top_k=final_limit,
+            )
+            rerank_time_ms = int((time.time() - rerank_start) * 1000)
+            final_results = reranked
+            reranking_applied = True
+        else:
+            final_results = vector_results[:final_limit]
+
+        # Build response
+        results = [
+            SearchResult(
+                id=r["id"],
+                content=r["content"],
+                metadata=r.get("metadata", {}),
+                similarity_score=r.get("similarity_score", 0.0),
+                relevance_score=r.get("relevance_score"),
+            )
+            for r in final_results
+        ]
+
+        # Detect backend type
+        backend_type = self._detect_backend_type(backend)
+        embedding_type = self._detect_embedding_type()
+
+        response = SearchResponse(
+            query=query,
+            results=results,
+            backend=backend_type,
+            embedding_provider=embedding_type,
+            reranking_applied=reranking_applied,
+            total_candidates=total_candidates,
+            search_time_ms=search_time_ms,
+            rerank_time_ms=rerank_time_ms,
+        )
+
+        # Cache result
+        self._set_cached(cache_key, response)
+
+        logger.debug(
+            f"Search completed: query='{query[:30]}...', "
+            f"candidates={total_candidates}, "
+            f"returned={len(results)}, "
+            f"time={search_time_ms}ms"
+            + (f"+{rerank_time_ms}ms rerank" if rerank_time_ms else "")
+        )
+
+        return response
+
+    # =========================================================================
+    # ONTOLOGY MATCHING (Compatible with DiseaseOntologyService API)
+    # =========================================================================
+
+    def match_ontology(
+        self,
+        term: str,
+        ontology: str,
+        k: int = 3,
+        min_confidence: float = 0.5,
+    ) -> List[OntologyMatch]:
+        """
+        Match free-text term to ontology concepts.
+
+        Compatible with existing DiseaseOntologyService.match_disease() API.
+        Enables seamless Phase 1 (keyword) to Phase 2 (embedding) migration.
+
+        Args:
+            term: Free-text term to match (e.g., "brain cortex", "colorectal cancer")
+            ontology: Ontology to search ("mondo", "uberon", "cl", "ncbi_taxonomy")
+            k: Number of candidates to consider
+            min_confidence: Minimum confidence threshold
+
+        Returns:
+            List of OntologyMatch sorted by confidence
+
+        Raises:
+            ValueError: If unknown ontology specified
+        """
+        # Get ontology-specific backend
+        backend = self._get_ontology_backend(ontology)
+
+        # Search with reranking for better precision
+        response = self.search(
+            query=term,
+            backend=backend,
+            vector_limit=k * 2,  # Get more candidates for filtering
+            final_limit=k,
+            use_reranking=True,  # Always rerank for ontology matching
+        )
+
+        # Convert to OntologyMatch format
+        collection_name = self.ONTOLOGY_COLLECTIONS.get(ontology.lower(), ontology)
+        matches = []
+        for result in response.results:
+            confidence = result.relevance_score or result.similarity_score
+
+            if confidence >= min_confidence:
+                matches.append(
+                    OntologyMatch(
+                        input_term=term,
+                        matched_term=result.metadata.get(
+                            "name", result.content[:50]
+                        ),
+                        ontology_id=result.id,
+                        ontology_source=collection_name.upper(),
+                        confidence=confidence,
+                        synonyms=result.metadata.get("synonyms", []),
+                        definition=result.content,
+                    )
+                )
+
+        return matches
+
+    def _get_ontology_backend(self, ontology: str) -> ChromaBackend:
+        """
+        Get or create ChromaDB backend for ontology.
+
+        Caches backends to avoid repeated initialization.
+
+        Args:
+            ontology: Ontology name or alias
+
+        Returns:
+            ChromaBackend for the ontology
+
+        Raises:
+            ValueError: If unknown ontology
+        """
+        ontology_lower = ontology.lower()
+        collection = self.ONTOLOGY_COLLECTIONS.get(ontology_lower)
+
+        if not collection:
+            available = ", ".join(sorted(set(self.ONTOLOGY_COLLECTIONS.values())))
+            raise ValueError(
+                f"Unknown ontology: {ontology}. Available: {available}"
+            )
+
+        if collection not in self._ontology_backends:
+            self._ontology_backends[collection] = ChromaBackend(
+                collection_name=collection
+            )
+
+        return self._ontology_backends[collection]
+
+    # =========================================================================
+    # LITERATURE SEARCH
+    # =========================================================================
+
+    def search_literature(
+        self,
+        query: str,
+        backend: BaseVectorBackend,
+        k: int = 5,
+        use_reranking: bool = True,
+    ) -> List[LiteratureMatch]:
+        """
+        Search literature by semantic similarity.
+
+        Args:
+            query: Research question or topic
+            backend: Pre-populated literature backend
+            k: Number of results
+            use_reranking: Enable Cohere reranking
+
+        Returns:
+            List of LiteratureMatch sorted by relevance
+        """
+        response = self.search(
+            query=query,
+            backend=backend,
+            vector_limit=k * 4,
+            final_limit=k,
+            use_reranking=use_reranking,
+        )
+
+        matches = []
+        for result in response.results:
+            matches.append(
+                LiteratureMatch(
+                    query=query,
+                    title=result.metadata.get("title", ""),
+                    abstract=result.content,
+                    doi=result.metadata.get("doi"),
+                    pmid=result.metadata.get("pmid"),
+                    relevance_score=result.relevance_score or result.similarity_score,
+                    matched_terms=result.metadata.get("matched_terms", []),
+                )
+            )
+
+        return matches
+
+    # =========================================================================
+    # CACHING
+    # =========================================================================
+
+    def _make_cache_key(
+        self,
+        query: str,
+        vector_limit: int,
+        final_limit: int,
+        use_reranking: bool,
+        backend_name: str,
+    ) -> str:
+        """Create cache key from search parameters."""
+        return f"{query}_{vector_limit}_{final_limit}_{use_reranking}_{backend_name}"
+
+    def _get_cached(self, key: str) -> Optional[Any]:
+        """Get cached result if not expired."""
+        if key in self._cache:
+            timestamp, value = self._cache[key]
+            if time.time() - timestamp < self.CACHE_TTL_SECONDS:
+                return value
+            del self._cache[key]
+        return None
+
+    def _set_cached(self, key: str, value: Any) -> None:
+        """Cache result with timestamp."""
+        self._cache[key] = (time.time(), value)
+
+    def clear_cache(self) -> None:
+        """Clear all cached results."""
+        self._cache.clear()
+        logger.debug("Search cache cleared")
+
+    # =========================================================================
+    # HELPERS
+    # =========================================================================
+
+    def _detect_backend_type(self, backend: BaseVectorBackend) -> SearchBackend:
+        """Detect backend type from instance."""
+        backend_name = backend.name.lower()
+        if "chroma" in backend_name:
+            return SearchBackend.CHROMA
+        elif "faiss" in backend_name:
+            return SearchBackend.FAISS
+        elif "pgvector" in backend_name:
+            return SearchBackend.PGVECTOR
+        return SearchBackend.FAISS  # Default
+
+    def _detect_embedding_type(self) -> EmbeddingProvider:
+        """Detect embedding provider type."""
+        model_name = self._embedding_provider.model_name.lower()
+        if "openai" in model_name or "embedding-3" in model_name:
+            return EmbeddingProvider.OPENAI
+        return EmbeddingProvider.SENTENCE_TRANSFORMERS
+
+    # =========================================================================
+    # IR GENERATION (for provenance)
+    # =========================================================================
+
+    def create_search_ir(
+        self,
+        query: str,
+        results_count: int,
+        search_type: str,
+    ) -> AnalysisStep:
+        """
+        Create IR for search operation (orchestration-only, not executable).
+
+        Args:
+            query: Search query
+            results_count: Number of results returned
+            search_type: Type of search ("ontology", "literature", "generic")
+
+        Returns:
+            AnalysisStep for provenance tracking
+        """
+        return AnalysisStep(
+            operation=f"vector_search_{search_type}",
+            tool_name=f"VectorSearchService.{search_type}",
+            description=f"Semantic search for: {query[:50]}... ({results_count} results)",
+            library="lobster.services.search",
+            code_template=f"""# Vector search performed
+# Query: {{{{ query }}}}
+# Results: {{{{ results_count }}}}
+# Type: {search_type}
+""",
+            imports=[],
+            parameters={"query": query, "results_count": results_count},
+            parameter_schema={},
+            input_entities=["query"],
+            output_entities=["search_results"],
+            exportable=False,  # Orchestration step
+        )

--- a/tests/integration/test_vector_search.py
+++ b/tests/integration/test_vector_search.py
@@ -1,0 +1,340 @@
+"""
+Integration tests for Vector Search Pipeline.
+
+Tests end-to-end vector search functionality including:
+- Ontology matching
+- Literature search
+- Graceful degradation without API keys
+"""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.mark.integration
+class TestVectorSearchIntegration:
+    """Integration tests for the vector search pipeline."""
+
+    @pytest.fixture
+    def mock_sentence_transformer(self):
+        """Mock SentenceTransformer to avoid downloading models in tests."""
+        with patch("sentence_transformers.SentenceTransformer") as mock:
+            mock_model = MagicMock()
+            mock_model.encode.return_value = np.random.rand(384).astype(np.float32)
+            mock_model.get_sentence_embedding_dimension.return_value = 384
+            mock.return_value = mock_model
+            yield mock_model
+
+    @pytest.fixture
+    def mock_faiss_index(self):
+        """Mock FAISS index."""
+        with patch("faiss.IndexFlatL2") as mock:
+            mock_index = MagicMock()
+            mock_index.ntotal = 0
+            mock_index.add = MagicMock()
+
+            def search_impl(query, k):
+                # Return valid indices and distances
+                n_docs = mock_index.ntotal
+                if n_docs == 0:
+                    return np.array([[-1]]), np.array([[float("inf")]])
+                actual_k = min(k, n_docs)
+                indices = np.arange(actual_k).reshape(1, -1)
+                distances = np.linspace(0, 1, actual_k).reshape(1, -1)
+                return distances, indices
+
+            mock_index.search.side_effect = search_impl
+            mock.return_value = mock_index
+            yield mock_index
+
+    def test_full_pipeline_faiss_backend(
+        self, mock_sentence_transformer, mock_faiss_index
+    ):
+        """Test full search pipeline with FAISS backend."""
+        from lobster.services.search import VectorSearchService
+        from lobster.services.search.backends import FAISSBackend
+        from lobster.services.search.embeddings import SentenceTransformersProvider
+
+        # Setup embedding provider
+        provider = SentenceTransformersProvider()
+
+        # Setup FAISS backend
+        backend = FAISSBackend(dimension=384)
+
+        # Add test documents
+        mock_faiss_index.ntotal = 3  # Set document count
+        backend._documents = {
+            "doc1": {"content": "Colorectal cancer treatment", "metadata": {}},
+            "doc2": {"content": "Breast cancer research", "metadata": {}},
+            "doc3": {"content": "Lung cancer diagnosis", "metadata": {}},
+        }
+        backend._idx_to_id = {0: "doc1", 1: "doc2", 2: "doc3"}
+        backend._id_to_idx = {"doc1": 0, "doc2": 1, "doc3": 2}
+
+        # Create service without reranking
+        service = VectorSearchService(
+            backend=backend,
+            embedding_provider=provider,
+            enable_reranking=False,
+        )
+
+        # Perform search
+        response = service.search(
+            query="cancer treatment",
+            vector_limit=10,
+            final_limit=3,
+        )
+
+        # Verify results
+        assert response.query == "cancer treatment"
+        assert len(response.results) <= 3
+        assert response.total_candidates >= 0
+        assert response.search_time_ms >= 0
+        assert not response.reranking_applied
+
+    def test_graceful_degradation_no_cohere(self, mock_sentence_transformer):
+        """Test service works without COHERE_API_KEY."""
+        from lobster.services.search import VectorSearchService
+        from lobster.services.search.embeddings import SentenceTransformersProvider
+        from lobster.services.search.reranker import CohereReranker
+
+        # Clear COHERE_API_KEY
+        with patch.dict("os.environ", {}, clear=True):
+            provider = SentenceTransformersProvider()
+            reranker = CohereReranker()  # Should be unavailable
+
+            assert not reranker.available
+
+            service = VectorSearchService(
+                embedding_provider=provider,
+                reranker=reranker,
+                enable_reranking=True,  # Try to enable
+            )
+
+            # Reranking should be disabled
+            assert not service.reranking_enabled
+
+    @patch("chromadb.PersistentClient")
+    def test_ontology_matching_flow(
+        self, mock_chroma_client, mock_sentence_transformer, tmp_path
+    ):
+        """Test ontology matching end-to-end."""
+        from lobster.services.search import VectorSearchService
+        from lobster.services.search.embeddings import SentenceTransformersProvider
+
+        # Setup mock ChromaDB
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.count.return_value = 100
+        mock_collection.query.return_value = {
+            "ids": [["MONDO:0005575", "MONDO:0005061"]],
+            "documents": [
+                [
+                    "Colorectal cancer - A cancer that begins in the colon or rectum",
+                    "Carcinoma of colon - Malignant tumor of colon",
+                ]
+            ],
+            "metadatas": [
+                [
+                    {"name": "colorectal cancer", "synonyms": ["CRC", "bowel cancer"]},
+                    {"name": "carcinoma of colon", "synonyms": ["colon carcinoma"]},
+                ]
+            ],
+            "distances": [[0.1, 0.2]],
+        }
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_chroma_client.return_value = mock_client
+
+        # Create collection directory
+        (tmp_path / "mondo").mkdir()
+
+        provider = SentenceTransformersProvider()
+
+        with patch(
+            "lobster.services.search.backends.chroma_backend.ChromaBackend.DEFAULT_CACHE_DIR",
+            str(tmp_path),
+        ):
+            service = VectorSearchService(
+                embedding_provider=provider,
+                enable_reranking=False,
+            )
+
+            # Override cache dir for test
+            service._ontology_backends = {}
+
+            with patch(
+                "lobster.services.search.vector_search_service.ChromaBackend"
+            ) as mock_chroma_backend:
+                mock_backend = MagicMock()
+                mock_backend.name = "chroma:mondo"
+                mock_backend.search.return_value = [
+                    {
+                        "id": "MONDO:0005575",
+                        "content": "Colorectal cancer definition",
+                        "metadata": {
+                            "name": "colorectal cancer",
+                            "synonyms": ["CRC"],
+                        },
+                        "similarity_score": 0.9,
+                    },
+                ]
+                mock_chroma_backend.return_value = mock_backend
+
+                matches = service.match_ontology(
+                    term="colon cancer",
+                    ontology="mondo",
+                    k=3,
+                    min_confidence=0.5,
+                )
+
+                assert len(matches) >= 1
+                assert matches[0].ontology_source == "MONDO"
+                assert matches[0].input_term == "colon cancer"
+
+    def test_literature_search_flow(
+        self, mock_sentence_transformer, mock_faiss_index
+    ):
+        """Test literature search end-to-end."""
+        from lobster.services.search import VectorSearchService
+        from lobster.services.search.backends import FAISSBackend
+        from lobster.services.search.embeddings import SentenceTransformersProvider
+
+        provider = SentenceTransformersProvider()
+        backend = FAISSBackend(dimension=384)
+
+        # Setup mock documents
+        mock_faiss_index.ntotal = 2
+        backend._documents = {
+            "pmid123": {
+                "content": "Single-cell RNA sequencing reveals cellular heterogeneity",
+                "metadata": {
+                    "title": "scRNA-seq Study",
+                    "pmid": "123",
+                    "doi": "10.1234/test",
+                },
+            },
+            "pmid456": {
+                "content": "Bulk RNA-seq analysis methods comparison",
+                "metadata": {
+                    "title": "Bulk RNA Study",
+                    "pmid": "456",
+                },
+            },
+        }
+        backend._idx_to_id = {0: "pmid123", 1: "pmid456"}
+        backend._id_to_idx = {"pmid123": 0, "pmid456": 1}
+
+        service = VectorSearchService(
+            embedding_provider=provider,
+            enable_reranking=False,
+        )
+
+        matches = service.search_literature(
+            query="single cell sequencing",
+            backend=backend,
+            k=5,
+            use_reranking=False,
+        )
+
+        assert len(matches) <= 2
+        for match in matches:
+            assert hasattr(match, "title")
+            assert hasattr(match, "pmid")
+            assert hasattr(match, "relevance_score")
+
+    def test_search_response_schema(
+        self, mock_sentence_transformer, mock_faiss_index
+    ):
+        """Test search response matches schema."""
+        from lobster.services.search import VectorSearchService
+        from lobster.services.search.backends import FAISSBackend
+        from lobster.services.search.embeddings import SentenceTransformersProvider
+        from lobster.core.schemas.search import SearchResponse, SearchBackend
+
+        provider = SentenceTransformersProvider()
+        backend = FAISSBackend(dimension=384)
+
+        mock_faiss_index.ntotal = 1
+        backend._documents = {"doc1": {"content": "Test", "metadata": {}}}
+        backend._idx_to_id = {0: "doc1"}
+        backend._id_to_idx = {"doc1": 0}
+
+        service = VectorSearchService(
+            embedding_provider=provider,
+            enable_reranking=False,
+        )
+
+        response = service.search("test", backend=backend)
+
+        # Verify response is valid SearchResponse
+        assert isinstance(response, SearchResponse)
+        assert response.backend == SearchBackend.FAISS
+        assert response.search_time_ms >= 0
+        assert isinstance(response.results, list)
+
+
+@pytest.mark.integration
+class TestVectorSearchWithRealModels:
+    """Integration tests that can optionally use real models.
+
+    These tests are skipped by default. Run with:
+    pytest tests/integration/test_vector_search.py -m "integration and real_api"
+    """
+
+    @pytest.mark.real_api
+    @pytest.mark.slow
+    def test_real_sentence_transformers(self):
+        """Test with real sentence-transformers model."""
+        pytest.importorskip("sentence_transformers")
+
+        from lobster.services.search.embeddings import SentenceTransformersProvider
+
+        provider = SentenceTransformersProvider()
+
+        # Generate real embedding
+        embedding = provider.embed_text("colorectal cancer treatment")
+
+        assert isinstance(embedding, np.ndarray)
+        assert embedding.shape == (384,)
+        assert not np.allclose(embedding, 0)  # Should not be all zeros
+
+    @pytest.mark.real_api
+    @pytest.mark.slow
+    def test_real_faiss_search(self):
+        """Test with real FAISS index."""
+        pytest.importorskip("faiss")
+        pytest.importorskip("sentence_transformers")
+
+        from lobster.services.search import VectorSearchService
+        from lobster.services.search.backends import FAISSBackend
+        from lobster.services.search.embeddings import SentenceTransformersProvider
+
+        provider = SentenceTransformersProvider()
+        backend = FAISSBackend(dimension=384)
+
+        # Add real documents with real embeddings
+        texts = [
+            "Colorectal cancer is a disease of the colon",
+            "Breast cancer affects the mammary glands",
+            "Lung cancer originates in lung tissue",
+        ]
+
+        embeddings = provider.embed_batch(texts)
+        ids = [f"doc{i}" for i in range(len(texts))]
+        metadatas = [{"index": i} for i in range(len(texts))]
+
+        backend.add_documents(ids, embeddings, texts, metadatas)
+
+        service = VectorSearchService(
+            backend=backend,
+            embedding_provider=provider,
+            enable_reranking=False,
+        )
+
+        # Search should find colorectal cancer document first
+        response = service.search("colon cancer treatment", backend=backend, final_limit=3)
+
+        assert len(response.results) == 3
+        # First result should be most relevant (colorectal cancer)
+        assert "colorectal" in response.results[0].content.lower()

--- a/tests/unit/services/search/__init__.py
+++ b/tests/unit/services/search/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for vector search service."""

--- a/tests/unit/services/search/test_backends.py
+++ b/tests/unit/services/search/test_backends.py
@@ -1,0 +1,325 @@
+"""
+Unit tests for vector search backends.
+
+Tests ChromaDB and FAISS backend implementations.
+"""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Check for optional dependencies
+try:
+    import faiss
+    HAS_FAISS = True
+except ImportError:
+    HAS_FAISS = False
+
+try:
+    import chromadb
+    HAS_CHROMADB = True
+except ImportError:
+    HAS_CHROMADB = False
+
+
+class TestBaseVectorBackend:
+    """Tests for BaseVectorBackend interface."""
+
+    def test_interface_contract(self):
+        """Verify the abstract interface defines required methods."""
+        from lobster.services.search.backends.base import BaseVectorBackend
+
+        # Check abstract methods exist
+        assert hasattr(BaseVectorBackend, "name")
+        assert hasattr(BaseVectorBackend, "add_documents")
+        assert hasattr(BaseVectorBackend, "search")
+        assert hasattr(BaseVectorBackend, "delete")
+        assert hasattr(BaseVectorBackend, "count")
+
+
+@pytest.mark.skipif(not HAS_FAISS, reason="FAISS not installed (pip install lobster-ai[search])")
+class TestFAISSBackend:
+    """Tests for FAISSBackend."""
+
+    @pytest.fixture
+    def mock_faiss(self):
+        """Mock FAISS import."""
+        with patch.dict("sys.modules", {"faiss": MagicMock()}):
+            yield
+
+    def test_initialization(self):
+        """Test backend initializes with dimension."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        backend = FAISSBackend(dimension=384)
+
+        assert backend.dimension == 384
+        assert backend.name == "faiss:memory"
+        assert backend._index is None  # Lazy initialization
+
+    def test_add_documents(self):
+        """Test adding documents to index."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        # Mock FAISS
+        with patch("faiss.IndexFlatL2") as mock_index_class:
+            mock_index = MagicMock()
+            mock_index.ntotal = 0
+            mock_index_class.return_value = mock_index
+
+            backend = FAISSBackend(dimension=4)
+
+            ids = ["doc1", "doc2"]
+            embeddings = [np.array([1, 0, 0, 0]), np.array([0, 1, 0, 0])]
+            texts = ["First document", "Second document"]
+            metadatas = [{"key": "value1"}, {"key": "value2"}]
+
+            backend.add_documents(ids, embeddings, texts, metadatas)
+
+            assert backend.count() == 2
+            assert "doc1" in backend._documents
+            assert "doc2" in backend._documents
+
+    def test_add_documents_validation(self):
+        """Test add_documents validates input lengths."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        with patch("faiss.IndexFlatL2"):
+            backend = FAISSBackend(dimension=4)
+
+            with pytest.raises(ValueError) as exc_info:
+                backend.add_documents(
+                    ids=["doc1", "doc2"],
+                    embeddings=[np.array([1, 0, 0, 0])],  # Wrong length
+                    texts=["Text"],
+                )
+
+            assert "same length" in str(exc_info.value)
+
+    def test_search(self):
+        """Test searching documents."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        # Mock FAISS
+        with patch("faiss.IndexFlatL2") as mock_index_class:
+            mock_index = MagicMock()
+            mock_index.ntotal = 2
+            mock_index.search.return_value = (
+                np.array([[0.0, 0.5]]),  # distances
+                np.array([[0, 1]]),  # indices
+            )
+            mock_index_class.return_value = mock_index
+
+            backend = FAISSBackend(dimension=4)
+
+            # Add documents first
+            backend._documents = {
+                "doc1": {"content": "First", "metadata": {}},
+                "doc2": {"content": "Second", "metadata": {}},
+            }
+            backend._idx_to_id = {0: "doc1", 1: "doc2"}
+            backend._id_to_idx = {"doc1": 0, "doc2": 1}
+            backend._index = mock_index
+
+            query = np.array([1, 0, 0, 0])
+            results = backend.search(query, k=2)
+
+            assert len(results) == 2
+            assert results[0]["id"] == "doc1"
+            assert results[1]["id"] == "doc2"
+            assert "similarity_score" in results[0]
+
+    def test_search_empty_index(self):
+        """Test search on empty index returns empty list."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        with patch("faiss.IndexFlatL2") as mock_index_class:
+            mock_index = MagicMock()
+            mock_index.ntotal = 0
+            mock_index_class.return_value = mock_index
+
+            backend = FAISSBackend(dimension=4)
+            results = backend.search(np.array([1, 0, 0, 0]), k=5)
+
+            assert results == []
+
+    def test_delete(self):
+        """Test deleting documents."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        with patch("faiss.IndexFlatL2"):
+            backend = FAISSBackend(dimension=4)
+            backend._documents = {"doc1": {"content": "Test", "metadata": {}}}
+            backend._id_to_idx = {"doc1": 0}
+            backend._idx_to_id = {0: "doc1"}
+
+            backend.delete(["doc1"])
+
+            assert "doc1" not in backend._documents
+            assert backend.count() == 0
+
+    def test_clear(self):
+        """Test clearing all documents."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        with patch("faiss.IndexFlatL2"):
+            backend = FAISSBackend(dimension=4)
+            backend._documents = {"doc1": {}, "doc2": {}}
+            backend._index = MagicMock()
+
+            backend.clear()
+
+            assert backend.count() == 0
+            assert backend._index is None
+
+    def test_add_document_convenience(self):
+        """Test add_document convenience method."""
+        from lobster.services.search.backends.faiss_backend import FAISSBackend
+
+        with patch("faiss.IndexFlatL2") as mock_index_class:
+            mock_index = MagicMock()
+            mock_index.ntotal = 0
+            mock_index_class.return_value = mock_index
+
+            backend = FAISSBackend(dimension=4)
+            backend.add_document(
+                doc_id="doc1",
+                text="Test document",
+                embedding=np.array([1, 0, 0, 0]),
+                metadata={"key": "value"},
+            )
+
+            assert backend.count() == 1
+
+
+@pytest.mark.skipif(not HAS_CHROMADB, reason="ChromaDB not installed (pip install lobster-ai[search])")
+class TestChromaBackend:
+    """Tests for ChromaBackend."""
+
+    def test_initialization(self):
+        """Test backend initializes without loading."""
+        from lobster.services.search.backends.chroma_backend import ChromaBackend
+
+        backend = ChromaBackend(
+            collection_name="test_collection",
+            auto_download=False,
+        )
+
+        assert backend.collection_name == "test_collection"
+        assert backend.name == "chroma:test_collection"
+        assert backend._client is None  # Lazy initialization
+
+    def test_initialization_custom_cache(self):
+        """Test backend accepts custom cache directory."""
+        from lobster.services.search.backends.chroma_backend import ChromaBackend
+
+        backend = ChromaBackend(
+            collection_name="test",
+            cache_dir="/custom/path",
+            auto_download=False,
+        )
+
+        assert str(backend.cache_dir) == "/custom/path"
+
+    @patch("chromadb.PersistentClient")
+    def test_add_documents(self, mock_client_class, tmp_path):
+        """Test adding documents to collection."""
+        from lobster.services.search.backends.chroma_backend import ChromaBackend
+
+        # Setup mock
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.count.return_value = 0
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_client_class.return_value = mock_client
+
+        # Create collection directory
+        collection_path = tmp_path / "test"
+        collection_path.mkdir()
+
+        backend = ChromaBackend(
+            collection_name="test",
+            cache_dir=str(tmp_path),
+            auto_download=False,
+        )
+
+        ids = ["doc1", "doc2"]
+        embeddings = [np.array([0.1, 0.2]), np.array([0.3, 0.4])]
+        texts = ["First", "Second"]
+
+        backend.add_documents(ids, embeddings, texts)
+
+        mock_collection.add.assert_called_once()
+
+    @patch("chromadb.PersistentClient")
+    def test_search(self, mock_client_class, tmp_path):
+        """Test searching collection."""
+        from lobster.services.search.backends.chroma_backend import ChromaBackend
+
+        # Setup mock
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_collection.count.return_value = 2
+        mock_collection.query.return_value = {
+            "ids": [["doc1", "doc2"]],
+            "documents": [["First", "Second"]],
+            "metadatas": [[{"key": "v1"}, {"key": "v2"}]],
+            "distances": [[0.1, 0.2]],
+        }
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_client_class.return_value = mock_client
+
+        # Create collection directory
+        collection_path = tmp_path / "test"
+        collection_path.mkdir()
+
+        backend = ChromaBackend(
+            collection_name="test",
+            cache_dir=str(tmp_path),
+            auto_download=False,
+        )
+
+        results = backend.search(np.array([0.1, 0.2]), k=2)
+
+        assert len(results) == 2
+        assert results[0]["id"] == "doc1"
+        assert results[0]["content"] == "First"
+        assert "similarity_score" in results[0]
+
+    def test_missing_collection_no_autodownload(self, tmp_path):
+        """Test raises error when collection missing and auto_download=False."""
+        from lobster.services.search.backends.chroma_backend import ChromaBackend
+
+        backend = ChromaBackend(
+            collection_name="missing",
+            cache_dir=str(tmp_path),
+            auto_download=False,
+        )
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            backend._ensure_downloaded()
+
+        assert "not found" in str(exc_info.value)
+
+    @patch("chromadb.PersistentClient")
+    def test_delete(self, mock_client_class, tmp_path):
+        """Test deleting documents."""
+        from lobster.services.search.backends.chroma_backend import ChromaBackend
+
+        mock_client = MagicMock()
+        mock_collection = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+        mock_client_class.return_value = mock_client
+
+        collection_path = tmp_path / "test"
+        collection_path.mkdir()
+
+        backend = ChromaBackend(
+            collection_name="test",
+            cache_dir=str(tmp_path),
+            auto_download=False,
+        )
+
+        backend.delete(["doc1", "doc2"])
+
+        mock_collection.delete.assert_called_once_with(ids=["doc1", "doc2"])

--- a/tests/unit/services/search/test_embeddings.py
+++ b/tests/unit/services/search/test_embeddings.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for embedding providers.
+
+Tests the embedding provider abstraction layer including
+local (sentence-transformers) and API (OpenAI) providers.
+"""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Check for optional dependencies
+try:
+    import sentence_transformers
+    HAS_SENTENCE_TRANSFORMERS = True
+except ImportError:
+    HAS_SENTENCE_TRANSFORMERS = False
+
+try:
+    import openai
+    HAS_OPENAI = True
+except ImportError:
+    HAS_OPENAI = False
+
+
+class TestBaseEmbeddingProvider:
+    """Tests for BaseEmbeddingProvider interface."""
+
+    def test_interface_contract(self):
+        """Verify the abstract interface defines required methods."""
+        from lobster.services.search.embeddings.base import BaseEmbeddingProvider
+
+        # Check abstract methods exist
+        assert hasattr(BaseEmbeddingProvider, "model_name")
+        assert hasattr(BaseEmbeddingProvider, "embedding_dimension")
+        assert hasattr(BaseEmbeddingProvider, "embed_text")
+        assert hasattr(BaseEmbeddingProvider, "embed_batch")
+
+
+@pytest.mark.skipif(not HAS_SENTENCE_TRANSFORMERS, reason="sentence-transformers not installed (pip install lobster-ai[search])")
+class TestSentenceTransformersProvider:
+    """Tests for SentenceTransformersProvider."""
+
+    def test_initialization(self):
+        """Test provider initializes without loading model."""
+        from lobster.services.search.embeddings.sentence_transformers import (
+            SentenceTransformersProvider,
+        )
+
+        provider = SentenceTransformersProvider()
+
+        assert provider.model_name == "all-MiniLM-L6-v2"
+        assert provider.embedding_dimension == 384
+        # Model should not be loaded yet (lazy initialization)
+        assert provider._model is None
+
+    def test_custom_model(self):
+        """Test provider accepts custom model name."""
+        from lobster.services.search.embeddings.sentence_transformers import (
+            SentenceTransformersProvider,
+        )
+
+        provider = SentenceTransformersProvider(model_name="all-mpnet-base-v2")
+
+        assert provider.model_name == "all-mpnet-base-v2"
+        assert provider.embedding_dimension == 768
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_embed_text(self, mock_st_class):
+        """Test single text embedding."""
+        from lobster.services.search.embeddings.sentence_transformers import (
+            SentenceTransformersProvider,
+        )
+
+        # Setup mock
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.zeros(384)
+        mock_model.get_sentence_embedding_dimension.return_value = 384
+        mock_st_class.return_value = mock_model
+
+        provider = SentenceTransformersProvider()
+        result = provider.embed_text("test query")
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (384,)
+        mock_model.encode.assert_called_once()
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_embed_batch(self, mock_st_class):
+        """Test batch embedding."""
+        from lobster.services.search.embeddings.sentence_transformers import (
+            SentenceTransformersProvider,
+        )
+
+        # Setup mock
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.zeros((3, 384))
+        mock_model.get_sentence_embedding_dimension.return_value = 384
+        mock_st_class.return_value = mock_model
+
+        provider = SentenceTransformersProvider()
+        result = provider.embed_batch(["text1", "text2", "text3"])
+
+        assert len(result) == 3
+        assert all(isinstance(e, np.ndarray) for e in result)
+
+    @patch("sentence_transformers.SentenceTransformer")
+    def test_embed_batch_empty(self, mock_st_class):
+        """Test batch embedding with empty list."""
+        from lobster.services.search.embeddings.sentence_transformers import (
+            SentenceTransformersProvider,
+        )
+
+        provider = SentenceTransformersProvider()
+        result = provider.embed_batch([])
+
+        assert result == []
+
+    def test_singleton_caching(self):
+        """Test get_sentence_transformers_provider caches instances."""
+        from lobster.services.search.embeddings.sentence_transformers import (
+            get_sentence_transformers_provider,
+        )
+
+        provider1 = get_sentence_transformers_provider("all-MiniLM-L6-v2")
+        provider2 = get_sentence_transformers_provider("all-MiniLM-L6-v2")
+
+        assert provider1 is provider2
+
+    def test_repr(self):
+        """Test string representation."""
+        from lobster.services.search.embeddings.sentence_transformers import (
+            SentenceTransformersProvider,
+        )
+
+        provider = SentenceTransformersProvider()
+
+        repr_str = repr(provider)
+        assert "SentenceTransformersProvider" in repr_str
+        assert "all-MiniLM-L6-v2" in repr_str
+
+
+@pytest.mark.skipif(not HAS_OPENAI, reason="openai not installed (pip install lobster-ai[search])")
+class TestOpenAIEmbeddingProvider:
+    """Tests for OpenAIEmbeddingProvider."""
+
+    def test_initialization_no_api_key(self):
+        """Test provider raises error without API key."""
+        from lobster.services.search.embeddings.openai_embeddings import (
+            OpenAIEmbeddingProvider,
+        )
+
+        # Remove API key from environment
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                OpenAIEmbeddingProvider()
+
+            assert "OPENAI_API_KEY" in str(exc_info.value)
+
+    def test_initialization_with_api_key(self):
+        """Test provider initializes with API key."""
+        from lobster.services.search.embeddings.openai_embeddings import (
+            OpenAIEmbeddingProvider,
+        )
+
+        provider = OpenAIEmbeddingProvider(api_key="test-key")
+
+        assert provider.model_name == "text-embedding-3-small"
+        assert provider.embedding_dimension == 1536
+        assert provider._client is None  # Lazy initialization
+
+    def test_custom_model(self):
+        """Test provider accepts custom model name."""
+        from lobster.services.search.embeddings.openai_embeddings import (
+            OpenAIEmbeddingProvider,
+        )
+
+        provider = OpenAIEmbeddingProvider(
+            api_key="test-key",
+            model_name="text-embedding-3-large",
+        )
+
+        assert provider.model_name == "text-embedding-3-large"
+        assert provider.embedding_dimension == 3072
+
+    @patch("openai.OpenAI")
+    def test_embed_text(self, mock_openai_class):
+        """Test single text embedding."""
+        from lobster.services.search.embeddings.openai_embeddings import (
+            OpenAIEmbeddingProvider,
+        )
+
+        # Setup mock
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=[0.1] * 1536)]
+        mock_client.embeddings.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+
+        provider = OpenAIEmbeddingProvider(api_key="test-key")
+        result = provider.embed_text("test query")
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (1536,)
+        mock_client.embeddings.create.assert_called_once()
+
+    @patch("openai.OpenAI")
+    def test_embed_batch(self, mock_openai_class):
+        """Test batch embedding."""
+        from lobster.services.search.embeddings.openai_embeddings import (
+            OpenAIEmbeddingProvider,
+        )
+
+        # Setup mock
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.data = [
+            MagicMock(embedding=[0.1] * 1536),
+            MagicMock(embedding=[0.2] * 1536),
+        ]
+        mock_client.embeddings.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+
+        provider = OpenAIEmbeddingProvider(api_key="test-key")
+        result = provider.embed_batch(["text1", "text2"])
+
+        assert len(result) == 2
+        assert all(isinstance(e, np.ndarray) for e in result)
+
+    @patch("openai.OpenAI")
+    def test_embed_batch_empty(self, mock_openai_class):
+        """Test batch embedding with empty list."""
+        from lobster.services.search.embeddings.openai_embeddings import (
+            OpenAIEmbeddingProvider,
+        )
+
+        provider = OpenAIEmbeddingProvider(api_key="test-key")
+        result = provider.embed_batch([])
+
+        assert result == []

--- a/tests/unit/services/search/test_reranker.py
+++ b/tests/unit/services/search/test_reranker.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for Cohere reranker.
+
+Tests the reranking functionality with graceful degradation.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Check for optional dependencies
+try:
+    import cohere
+    HAS_COHERE = True
+except ImportError:
+    HAS_COHERE = False
+
+
+@pytest.mark.skipif(not HAS_COHERE, reason="cohere not installed (pip install lobster-ai[search])")
+class TestCohereReranker:
+    """Tests for CohereReranker."""
+
+    def test_initialization_no_api_key(self):
+        """Test reranker initializes but marks unavailable without API key."""
+        from lobster.services.search.reranker import CohereReranker
+
+        with patch.dict("os.environ", {}, clear=True):
+            reranker = CohereReranker()
+
+            assert not reranker.available
+            assert reranker.model == "rerank-english-v3.0"
+
+    def test_initialization_with_api_key(self):
+        """Test reranker initializes with API key."""
+        from lobster.services.search.reranker import CohereReranker
+
+        reranker = CohereReranker(api_key="test-key")
+
+        assert reranker.available
+        assert reranker._client is None  # Lazy initialization
+
+    def test_initialization_from_env(self):
+        """Test reranker reads API key from environment."""
+        from lobster.services.search.reranker import CohereReranker
+
+        with patch.dict("os.environ", {"COHERE_API_KEY": "env-key"}):
+            reranker = CohereReranker()
+
+            assert reranker.available
+
+    def test_custom_model(self):
+        """Test reranker accepts custom model."""
+        from lobster.services.search.reranker import CohereReranker
+
+        reranker = CohereReranker(
+            api_key="test-key",
+            model="rerank-multilingual-v3.0",
+        )
+
+        assert reranker.model == "rerank-multilingual-v3.0"
+
+    def test_rerank_unavailable_returns_original(self):
+        """Test rerank returns original order when unavailable."""
+        from lobster.services.search.reranker import CohereReranker
+
+        with patch.dict("os.environ", {}, clear=True):
+            reranker = CohereReranker()
+
+            documents = [
+                {"content": "First"},
+                {"content": "Second"},
+                {"content": "Third"},
+            ]
+
+            result = reranker.rerank("query", documents, top_k=2)
+
+            # Should return first 2 documents in original order
+            assert len(result) == 2
+            assert result[0]["content"] == "First"
+            assert result[1]["content"] == "Second"
+
+    def test_rerank_empty_documents(self):
+        """Test rerank handles empty document list."""
+        from lobster.services.search.reranker import CohereReranker
+
+        reranker = CohereReranker(api_key="test-key")
+        result = reranker.rerank("query", [], top_k=5)
+
+        assert result == []
+
+    def test_rerank_single_document(self):
+        """Test rerank handles single document."""
+        from lobster.services.search.reranker import CohereReranker
+
+        reranker = CohereReranker(api_key="test-key")
+        documents = [{"content": "Only document"}]
+
+        result = reranker.rerank("query", documents, top_k=5)
+
+        assert len(result) == 1
+        assert result[0]["content"] == "Only document"
+        assert result[0]["relevance_score"] == 1.0
+
+    @patch("cohere.Client")
+    def test_rerank_with_api(self, mock_client_class):
+        """Test rerank calls Cohere API correctly."""
+        from lobster.services.search.reranker import CohereReranker
+
+        # Setup mock
+        mock_client = MagicMock()
+        mock_result1 = MagicMock()
+        mock_result1.index = 1
+        mock_result1.relevance_score = 0.95
+        mock_result2 = MagicMock()
+        mock_result2.index = 0
+        mock_result2.relevance_score = 0.85
+        mock_response = MagicMock()
+        mock_response.results = [mock_result1, mock_result2]
+        mock_client.rerank.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        reranker = CohereReranker(api_key="test-key")
+
+        documents = [
+            {"content": "First document"},
+            {"content": "Second document"},
+        ]
+
+        result = reranker.rerank("test query", documents, top_k=2)
+
+        # Should be reordered based on relevance
+        assert len(result) == 2
+        assert result[0]["content"] == "Second document"
+        assert result[0]["relevance_score"] == 0.95
+        assert result[1]["content"] == "First document"
+        assert result[1]["relevance_score"] == 0.85
+
+        mock_client.rerank.assert_called_once()
+
+    @patch("cohere.Client")
+    def test_rerank_with_min_relevance(self, mock_client_class):
+        """Test rerank filters by minimum relevance."""
+        from lobster.services.search.reranker import CohereReranker
+
+        # Setup mock
+        mock_client = MagicMock()
+        mock_result1 = MagicMock()
+        mock_result1.index = 0
+        mock_result1.relevance_score = 0.9
+        mock_result2 = MagicMock()
+        mock_result2.index = 1
+        mock_result2.relevance_score = 0.3
+        mock_response = MagicMock()
+        mock_response.results = [mock_result1, mock_result2]
+        mock_client.rerank.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        reranker = CohereReranker(api_key="test-key")
+
+        documents = [
+            {"content": "Relevant"},
+            {"content": "Not relevant"},
+        ]
+
+        result = reranker.rerank(
+            "test query",
+            documents,
+            top_k=2,
+            min_relevance=0.5,
+        )
+
+        # Only the first result should pass threshold
+        assert len(result) == 1
+        assert result[0]["content"] == "Relevant"
+
+    @patch("cohere.Client")
+    def test_rerank_includes_title(self, mock_client_class):
+        """Test rerank includes title in text when available."""
+        from lobster.services.search.reranker import CohereReranker
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.results = [
+            MagicMock(index=0, relevance_score=0.9),
+        ]
+        mock_client.rerank.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        reranker = CohereReranker(api_key="test-key")
+
+        documents = [
+            {
+                "content": "Content text",
+                "metadata": {"title": "Document Title"},
+            },
+        ]
+
+        reranker.rerank("query", documents, top_k=1)
+
+        # Check that title was included in the text
+        call_args = mock_client.rerank.call_args
+        texts = call_args.kwargs["documents"]
+        assert "Document Title" in texts[0]
+
+    @patch("cohere.Client")
+    def test_rerank_api_error_returns_original(self, mock_client_class):
+        """Test rerank returns original order on API error."""
+        from lobster.services.search.reranker import CohereReranker
+
+        mock_client = MagicMock()
+        mock_client.rerank.side_effect = Exception("API Error")
+        mock_client_class.return_value = mock_client
+
+        reranker = CohereReranker(api_key="test-key")
+
+        documents = [
+            {"content": "First"},
+            {"content": "Second"},
+        ]
+
+        result = reranker.rerank("query", documents, top_k=2)
+
+        # Should gracefully fall back to original order
+        assert len(result) == 2
+        assert result[0]["content"] == "First"
+
+    def test_rerank_texts_convenience(self):
+        """Test rerank_texts convenience method."""
+        from lobster.services.search.reranker import CohereReranker
+
+        with patch.dict("os.environ", {}, clear=True):
+            reranker = CohereReranker()
+
+            texts = ["First text", "Second text"]
+            result = reranker.rerank_texts("query", texts, top_k=2)
+
+            assert len(result) == 2
+            assert result[0]["content"] == "First text"

--- a/tests/unit/services/search/test_vector_search_service.py
+++ b/tests/unit/services/search/test_vector_search_service.py
@@ -1,0 +1,347 @@
+"""
+Unit tests for VectorSearchService.
+
+Tests the main unified search service with all features.
+"""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestVectorSearchService:
+    """Tests for VectorSearchService."""
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        """Create mock embedding provider."""
+        provider = MagicMock()
+        provider.model_name = "test-model"
+        provider.embedding_dimension = 384
+        provider.embed_text.return_value = np.zeros(384)
+        provider.embed_batch.return_value = [np.zeros(384)]
+        return provider
+
+    @pytest.fixture
+    def mock_backend(self):
+        """Create mock vector backend."""
+        backend = MagicMock()
+        backend.name = "mock:test"
+        backend.search.return_value = [
+            {
+                "id": "doc1",
+                "content": "Test content 1",
+                "metadata": {"key": "value1"},
+                "similarity_score": 0.9,
+            },
+            {
+                "id": "doc2",
+                "content": "Test content 2",
+                "metadata": {"key": "value2"},
+                "similarity_score": 0.8,
+            },
+        ]
+        return backend
+
+    @pytest.fixture
+    def mock_reranker(self):
+        """Create mock reranker."""
+        reranker = MagicMock()
+        reranker.available = True
+        reranker.rerank.return_value = [
+            {
+                "id": "doc1",
+                "content": "Test content 1",
+                "metadata": {"key": "value1"},
+                "similarity_score": 0.9,
+                "relevance_score": 0.95,
+            },
+        ]
+        return reranker
+
+    def test_initialization(self, mock_embedding_provider, mock_reranker):
+        """Test service initializes correctly."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+        )
+
+        assert service.embedding_provider == mock_embedding_provider
+        assert service.reranking_enabled
+
+    def test_initialization_default_provider(self):
+        """Test service initializes with default provider."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        with patch(
+            "lobster.services.search.vector_search_service.get_sentence_transformers_provider"
+        ) as mock_get:
+            mock_provider = MagicMock()
+            mock_provider.model_name = "all-MiniLM-L6-v2"
+            mock_get.return_value = mock_provider
+
+            service = VectorSearchService()
+
+            assert service._embedding_provider == mock_provider
+
+    def test_search_requires_backend(self, mock_embedding_provider, mock_reranker):
+        """Test search raises error without backend."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            service.search("test query")
+
+        assert "No backend configured" in str(exc_info.value)
+
+    def test_search_basic(
+        self, mock_embedding_provider, mock_backend, mock_reranker
+    ):
+        """Test basic search functionality."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        mock_reranker.available = False  # Disable reranking for this test
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+            enable_reranking=False,
+        )
+
+        response = service.search("test query", backend=mock_backend)
+
+        assert response.query == "test query"
+        assert len(response.results) > 0
+        assert response.total_candidates == 2
+        assert response.search_time_ms >= 0
+        assert not response.reranking_applied
+
+    def test_search_with_reranking(
+        self, mock_embedding_provider, mock_backend, mock_reranker
+    ):
+        """Test search with reranking enabled."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+            enable_reranking=True,
+        )
+
+        response = service.search("test query", backend=mock_backend)
+
+        assert response.reranking_applied
+        assert response.rerank_time_ms is not None
+        mock_reranker.rerank.assert_called_once()
+
+    def test_search_caching(
+        self, mock_embedding_provider, mock_backend, mock_reranker
+    ):
+        """Test search results are cached."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        mock_reranker.available = False
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+            enable_reranking=False,
+        )
+
+        # First search
+        response1 = service.search("test query", backend=mock_backend)
+
+        # Second search with same query
+        response2 = service.search("test query", backend=mock_backend)
+
+        # Backend should only be called once (second is cached)
+        assert mock_backend.search.call_count == 1
+        assert response1.query == response2.query
+
+    def test_search_cache_clear(
+        self, mock_embedding_provider, mock_backend, mock_reranker
+    ):
+        """Test cache can be cleared."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        mock_reranker.available = False
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+            enable_reranking=False,
+        )
+
+        service.search("test query", backend=mock_backend)
+        service.clear_cache()
+        service.search("test query", backend=mock_backend)
+
+        # Backend should be called twice (cache was cleared)
+        assert mock_backend.search.call_count == 2
+
+    def test_match_ontology(
+        self, mock_embedding_provider, mock_reranker
+    ):
+        """Test ontology matching."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        # Create mock ChromaBackend
+        with patch(
+            "lobster.services.search.vector_search_service.ChromaBackend"
+        ) as mock_chroma:
+            mock_backend = MagicMock()
+            mock_backend.name = "chroma:mondo"
+            mock_backend.search.return_value = [
+                {
+                    "id": "MONDO:0005575",
+                    "content": "Colorectal cancer definition",
+                    "metadata": {"name": "colorectal cancer", "synonyms": []},
+                    "similarity_score": 0.9,
+                },
+            ]
+            mock_chroma.return_value = mock_backend
+
+            service = VectorSearchService(
+                embedding_provider=mock_embedding_provider,
+                reranker=mock_reranker,
+                enable_reranking=True,
+            )
+
+            matches = service.match_ontology(
+                term="colorectal cancer",
+                ontology="mondo",
+                k=3,
+                min_confidence=0.5,
+            )
+
+            assert len(matches) == 1
+            assert matches[0].input_term == "colorectal cancer"
+            assert matches[0].ontology_source == "MONDO"
+
+    def test_match_ontology_unknown_ontology(
+        self, mock_embedding_provider, mock_reranker
+    ):
+        """Test match_ontology raises error for unknown ontology."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            service.match_ontology("term", ontology="unknown")
+
+        assert "Unknown ontology" in str(exc_info.value)
+
+    def test_search_literature(
+        self, mock_embedding_provider, mock_backend, mock_reranker
+    ):
+        """Test literature search."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        # Update mock backend response
+        mock_backend.search.return_value = [
+            {
+                "id": "pmid123",
+                "content": "Study abstract text",
+                "metadata": {
+                    "title": "Study Title",
+                    "pmid": "123",
+                    "doi": "10.1234/test",
+                },
+                "similarity_score": 0.9,
+            },
+        ]
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+            enable_reranking=False,
+        )
+
+        matches = service.search_literature(
+            query="single cell RNA-seq",
+            backend=mock_backend,
+            k=5,
+            use_reranking=False,
+        )
+
+        assert len(matches) == 1
+        assert matches[0].title == "Study Title"
+        assert matches[0].pmid == "123"
+        assert matches[0].query == "single cell RNA-seq"
+
+    def test_create_search_ir(self, mock_embedding_provider, mock_reranker):
+        """Test IR generation for provenance."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+        )
+
+        ir = service.create_search_ir(
+            query="test query",
+            results_count=5,
+            search_type="ontology",
+        )
+
+        assert ir.operation == "vector_search_ontology"
+        assert "test query" in ir.description
+        assert ir.exportable is False
+
+    def test_backend_type_detection(self, mock_embedding_provider, mock_reranker):
+        """Test backend type detection."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+        from lobster.core.schemas.search import SearchBackend
+
+        service = VectorSearchService(
+            embedding_provider=mock_embedding_provider,
+            reranker=mock_reranker,
+        )
+
+        mock_backend = MagicMock()
+
+        mock_backend.name = "chroma:test"
+        assert service._detect_backend_type(mock_backend) == SearchBackend.CHROMA
+
+        mock_backend.name = "faiss:memory"
+        assert service._detect_backend_type(mock_backend) == SearchBackend.FAISS
+
+        mock_backend.name = "pgvector:postgres"
+        assert service._detect_backend_type(mock_backend) == SearchBackend.PGVECTOR
+
+
+class TestVectorSearchServiceOntologyMapping:
+    """Tests for ontology collection mapping."""
+
+    def test_ontology_aliases(self):
+        """Test ontology aliases map correctly."""
+        from lobster.services.search.vector_search_service import VectorSearchService
+
+        mapping = VectorSearchService.ONTOLOGY_COLLECTIONS
+
+        # Disease aliases
+        assert mapping["mondo"] == "mondo"
+        assert mapping["disease"] == "mondo"
+
+        # Tissue aliases
+        assert mapping["uberon"] == "uberon"
+        assert mapping["tissue"] == "uberon"
+
+        # Cell type aliases
+        assert mapping["cl"] == "cell_ontology"
+        assert mapping["cell_type"] == "cell_ontology"
+        assert mapping["cell_ontology"] == "cell_ontology"
+
+        # Organism aliases
+        assert mapping["ncbi_taxonomy"] == "ncbi_taxonomy"
+        assert mapping["organism"] == "ncbi_taxonomy"
+        assert mapping["taxonomy"] == "ncbi_taxonomy"


### PR DESCRIPTION
## Overview
Implements unified vector search infrastructure for literature search and ontology standardization with a two-stage pipeline (vector search → reranking).

## Architecture
```
VectorSearchService
├── Embedding Providers
│   ├── SentenceTransformers (default: all-MiniLM-L6-v2, 384 dims, local, free)
│   └── OpenAI (text-embedding-3-small, 1536 dims, API)
├── Vector Backends
│   ├── ChromaDB (persistent storage for ontologies)
│   └── FAISS (ephemeral storage for literature)
└── Reranker
    └── Cohere (with graceful degradation)
```

## Key Features
- **Two-stage pipeline**: Vector search (20 candidates) → Cohere rerank (top 5)
- **Default embeddings**: `all-MiniLM-L6-v2` (local, free, no API costs)
- **Optional dependencies**: `pip install lobster-ai[search]` for faiss/chromadb/cohere
- **Graceful degradation**: Returns original order if reranking unavailable
- **5-minute query caching** for repeated searches
- **API-compatible** with existing `DiseaseOntologyService`

## Files Added
- `lobster/core/schemas/search.py` - Enums and models
- `lobster/services/search/vector_search_service.py` - Main service
- `lobster/services/search/reranker.py` - Cohere reranking
- `lobster/services/search/backends/` - ChromaDB, FAISS implementations
- `lobster/services/search/embeddings/` - SentenceTransformers, OpenAI providers
- Unit tests (4 test files, 51 tests)
- Integration tests

## Files Modified
- `lobster/core/schemas/__init__.py` - Added search schema exports

## Testing
- ✅ 21 tests passing, 33 skipped (when optional deps not installed)
- ✅ Live testing with graceful degradation verified
- ✅ Proper `@pytest.mark.skipif` decorators for optional dependencies

## Implementation Notes
- Follows BioAgents IMPL_PLAN_03 specification
- ChromaDB follows BioAgents lazy download strategy (no build scripts)
- All imports wrapped in try/except for graceful degradation
- No breaking changes to existing code

## Related
Part of BioAgents feature integration (3/3 features).

## Dependencies to Add
```toml
[project.optional-dependencies]
search = [
    "chromadb>=0.4.0",
    "sentence-transformers>=2.2.0",
    "faiss-cpu>=1.7.0",
    "cohere>=4.0.0",
    "openai>=1.0.0",
]
```