### PR TITLE
fix(ci): mint GitHub App token for lobster-cloud deploy dispatch

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -700,10 +700,24 @@ jobs:
       - name: Wait for PyPI index propagation
         run: sleep 60
 
+      # Mint a short-lived GitHub App installation token scoped to lobster-cloud.
+      # Replaces the expiry-prone LOBSTER_CLOUD_DEPLOY_TOKEN PAT — the app token
+      # is generated per-run and expires in ~1h, so there is nothing to rotate.
+      # Uses the org "lobster-the-dev" app (contents:write), which is what
+      # repository_dispatch requires.
+      - name: Mint lobster-cloud deploy token
+        id: cloud_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: the-omics-os
+          repositories: lobster-cloud
+
       - name: Dispatch to lobster-cloud
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.LOBSTER_CLOUD_DEPLOY_TOKEN }}
+          token: ${{ steps.cloud_token.outputs.token }}
           repository: the-omics-os/lobster-cloud
           event-type: lobster-packages-published
           client-payload: >-


### PR DESCRIPTION
## Problem

The `Trigger Cloud Deploy` job in `publish-packages.yml` dispatches a `repository_dispatch` event to `the-omics-os/lobster-cloud` (which `deploy-backend.yml` listens for). It authenticated with `secrets.LOBSTER_CLOUD_DEPLOY_TOKEN` — a PAT last set **2026-02-15**, now expired.

Result: **`Bad credentials`** on the dispatch step for every release since at least **v1.1.418 (2026-05-02)**. PyPI publish succeeded, but the automatic cloud deploy never fired. Confirmed on the v1.1.419 release run today.

## Fix

Replace the static PAT with a **per-run GitHub App installation token** via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token), scoped to `lobster-cloud` only.

- Uses the existing org app **`lobster-the-dev`** (app id `2888695`) — already installed on all repos, with `contents: write` (the permission `repository_dispatch` requires).
- Reads `secrets.APP_ID` (org, all-repo) + `secrets.APP_PRIVATE_KEY` (repo) — **both already present** in this repo.
- Token is minted at run time and expires in ~1h → **nothing to rotate, this failure cannot recur.**

No change to the dispatch `event-type` or `client-payload`. Verified YAML parses.

## After merge

- `secrets.LOBSTER_CLOUD_DEPLOY_TOKEN` is no longer referenced and can be deleted.
- Next release's cloud deploy will fire automatically.

## Note

v1.1.419 cloud deploy was triggered manually via `workflow_dispatch` (`deploy-backend.yml -f version=1.1.419`) as a stopgap — this PR fixes the automatic path for future releases.