### PR TITLE
fix(research): recognize bulk RNA-seq raw/count matrices in GEO strategy extraction

### DIFF
--- a/packages/lobster-research/lobster/agents/data_expert/assistant.py
+++ b/packages/lobster-research/lobster/agents/data_expert/assistant.py
@@ -46,18 +46,22 @@ class StrategyConfig(BaseModel):
     summary_file_type: str = Field(
         default="", description="Filetype of the Summary File. Example: 'xlsx'"
     )
+
     processed_matrix_name: str = Field(
         default="",
-        description="name of the TARGET processed (log2, tpm, normalized, etc) matrix file (preference is non R objects). Example: 'GSE131907_Lung_Cancer_normalized_log2TPM_matrix'",
+        description="name of the TARGET processed (log2, tpm, fpkm, normalized, etc) matrix file, including bulk RNA-seq normalized matrices (preference is non R objects). Example: 'GSE131907_Lung_Cancer_normalized_log2TPM_matrix'",
     )
+
     processed_matrix_filetype: str = Field(
         default="",
         description="filetype of the TARGET processed file (preference is non R objects). Example: 'txt'",
     )
+
     raw_UMI_like_matrix_name: str = Field(
         default="",
-        description="name of the raw TARGET UMI-like (UMI, raw, tar) matrix file (preference is non R objects). Example: 'GSE131907_Lung_Cancer_raw_UMI_matrix'",
+        description="name of the raw TARGET UMI-like (UMI, raw, tar) or bulk unnormalized/gene count matrix file; if a file has raw integer counts (names with 'raw', 'counts', 'unnormalised') it belongs here, not in processed (preference is non R objects). Example: 'GSE131907_Lung_Cancer_raw_UMI_matrix'",
     )
+
     raw_UMI_like_matrix_filetype: str = Field(
         default="",
         description="filetype of the TARGET raw UMI-like file (preference is non R objects). Example: 'txt'",


### PR DESCRIPTION
## Description
While I was trying out DGE analyses on some GEO bulk RNA-seq datasets, it kept on having trouble finding the raw count files. Looking deeper, `DataExpertAssistant.extract_strategy_config` frequently left both `processed_matrix_name` and `raw_UMI_like_matrix_name` empty. Empty slots make `PipelineContext.data_availability` (in `geo/strategy.py`) evaluate to `NONE`, which skips `ProcessedMatrixRule`/`RawMatrixRule` and falls through to `SUPPLEMENTARY_FIRST`, downloading whatever supplementary file comes first.

Repro (GSE184616): the FPKM-normalized file was loaded instead of the raw counts, producing a matrix unsuitable for count-based DE (DESeq2/edgeR) with no error raised (only downstream warnings: "Very large values...", "check_count_data failed"). This would silently cause an incorrect analysis downstream.

Root cause: It seems the `StrategyConfig` field descriptions were single-cell-centric ("UMI-like"), so bulk gene-count files were borderline and often left unclassified. I tried to implement a very minimal change to fix that. This PR broadens two field descriptions (additive only) so bulk unnormalized/count files map to the raw slot and FPKM/normalized files to the processed slot.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Breaking change

## Testing
Testing out a couple of different variations. To make sure the change worked, I validated via a reproducible manual harness calling `extract_strategy_config` N×/dataset (GPT-4o, default settings). 

I also wanted to make sure the changes didn't accidentally mess up the flow for single-cell files, so I tested that out too on 10 single-cell datasets before and after the changes.

**Bulk target (GSE184616):** raw-slot fill rate before was ~80% (16/20) → after the change is ~95% (19/20).

**Single-cell non-regression (10 runs/dataset, before vs after via `git stash`):**

| GSE | raw before | raw after |
|-----|-----------|-----------|
| GSE131907 | 9/10 | 9/10 |
| GSE156793 | 1/10 | 8/10 |
| GSE111672 | 0/10 | 0/10 |
| GSE150825 | 5/10 | 5/10 |
| GSE180759 | 0/10 | 0/10 |
| GSE136831 | 7/10 | 8/10 |
| GSE164690 | 0/10 | 0/10 |
| GSE123813 | 2/10 | 0/10 |
| GSE72056 | 0/10 | 0/10 |
| GSE118389 | 8/10 | 10/10 |

No raw-slot regressions; one dataset improved (GSE156793 +7). GSE123813's -2 coincided with an OpenAI 429 rate limit on one call and is within run-to-run variance.

- [ ] Tests added/updated — no automated test added; validated via the manual harness above. Happy to add a regression test if preferred.
- [ ] Contract tests pass — could not run `pytest -m contract` / `make test` locally (test deps `responses`/`faker` absent in my Windows env; `make` unavailable on Windows). This change modifies only two Pydantic field descriptions — no tools, no AQUADIF metadata, no services — so it touches no contract-governed code. CI will run the full suite.
- [x] Manual testing performed

## Known limitation / recommended follow-up
Residual empties are non-deterministic: these classification calls run at temperature 1.0, so identical input occasionally yields empty slots (the single-cell "before" rates above are already noisy on unmodified code). This was actually the case across the many different changes we tested. Recommend pinning `extract_strategy_config` / `detect_modality` to `temperature=0.1` as a separate change. Separately, `ProcessedMatrixRule` (priority 100) outranks `RawMatrixRule` (priority 90), so when both a processed and raw matrix exist the normalized file wins. This is worth reconsidering for count-based DGE workflows where mostly you need raw counts.

## Checklist
- [x] Code follows project style
- [ ] AQUADIF metadata assigned to new tools (N/A — no new tools)
- [ ] Provenance passed in log_tool_usage for new tools (N/A — no new tools)
- [x] Self-review completed