### PR TITLE
fix(config): read CDK deploy account from env (redact hardcoded AWS account ID)

### DIFF
--- a/lobster/config/settings.py
+++ b/lobster/config/settings.py
@@ -43,7 +43,7 @@ class Settings:
 
         # CDK variables (used by lobster-cloud deployment)
         self.STACK_NAME = "LobsterStack"
-        self.CDK_DEPLY_ACCOUNT = "649207544517"
+        self.CDK_DEPLY_ACCOUNT = os.environ.get("CDK_DEPLOY_ACCOUNT", "")
         # AWS Fargate CPU/Memory options summary:
         # - 256 (.25 vCPU): 512 MiB, 1 GB, 2 GB (Linux)
         # - 512 (.5 vCPU): 1 GB, 2 GB, 3 GB, 4 GB (Linux)


### PR DESCRIPTION
## Security: redact private AWS account ID from public package

**Found during pre-release security scan of the v1.1.420 build artifacts.**

`lobster/config/settings.py` hardcoded a private AWS account ID as a string literal in `CDK_DEPLY_ACCOUNT`. Since `lobster-ai` publishes to **public PyPI**, that constant shipped inside both the sdist and the wheel of the most-installed package.

### Why it's safe to change
- The value is only meaningful to the **separate** `lobster-cloud` deploy repo.
- It is **dead code here** — zero references in `lobster/` or `packages/` (only the definition line).
- Every other AWS/credential value in `settings.py` already reads from env; this one was the lone hardcoded outlier.

### Fix
```python
- self.CDK_DEPLY_ACCOUNT = "<hardcoded account id>"
+ self.CDK_DEPLY_ACCOUNT = os.environ.get("CDK_DEPLOY_ACCOUNT", "")
```
Attribute preserved (external `get_settings()` readers keep working; resolves to empty unless the deploy env sets it).

### Verified
- Account ID no longer in any tracked source (`grep` clean across `lobster/` + `packages/`).
- Fresh `uv build` of core: **0 occurrences** in both sdist and wheel.
- `get_settings()` imports clean; field returns `''`.

**Gates the v1.1.420 release** — must land before tagging so the leaked ID never publishes.

Scan also confirmed (clean): no other hardcoded secrets/tokens/keys, and **zero LobsterHoney/beacon exposure** in published bytes.