### PR TITLE
feat(providers): add Nebius AI Studio open-model provider

### DIFF
--- a/lobster/config/constants.py
+++ b/lobster/config/constants.py
@@ -17,6 +17,7 @@ VALID_PROVIDERS: Final[List[str]] = [
     "openai",
     "openrouter",
     "omics-os",
+    "nebius",
 ]
 
 # Valid agent configuration profiles
@@ -44,4 +45,5 @@ PROVIDER_DISPLAY_NAMES: Final[dict] = {
     "openai": "OpenAI",
     "openrouter": "OpenRouter (600+ models)",
     "omics-os": "Omics-OS Cloud",
+    "nebius": "Nebius AI Studio",
 }

--- a/lobster/config/providers/__init__.py
+++ b/lobster/config/providers/__init__.py
@@ -23,6 +23,7 @@ Usage:
 """
 
 from lobster.config.providers.base_provider import ILLMProvider, ModelInfo
+from lobster.config.providers.nebius_provider import NebiusProvider
 from lobster.config.providers.openrouter_provider import OpenRouterProvider
 from lobster.config.providers.registry import ProviderRegistry, get_provider
 
@@ -32,4 +33,5 @@ __all__ = [
     "ProviderRegistry",
     "get_provider",
     "OpenRouterProvider",
+    "NebiusProvider",
 ]

--- a/lobster/config/providers/nebius_provider.py
+++ b/lobster/config/providers/nebius_provider.py
@@ -1,0 +1,364 @@
+"""
+Nebius AI Studio provider implementation.
+
+Nebius AI Studio (Token Factory) is an OpenAI-wire-compatible inference
+platform hosting open-weight models (Qwen, DeepSeek, Kimi, GLM, MiniMax,
+Hermes, NVIDIA Nemotron/Cosmos, Gemma). It speaks the OpenAI API protocol,
+so no new LangChain packages are required — ChatOpenAI with a base_url
+override is sufficient.
+
+API key setup: https://nebius.com (Token Factory / AI Studio dashboard)
+
+Architecture:
+    - Implements ILLMProvider interface
+    - Uses ChatOpenAI with base_url override (OpenAI-compatible API)
+    - Static KNOWN_MODELS catalog carrying pricing (no live catalog fetch)
+    - No new dependencies — uses ChatOpenAI, no default_headers/branding
+
+Model naming convention: "org/model-name" (e.g., "Qwen/Qwen3-30B-A3B-Instruct-2507")
+
+Example:
+    >>> provider = NebiusProvider()
+    >>> if provider.is_configured():
+    ...     models = provider.list_models()
+    ...     llm = provider.create_chat_model("Qwen/Qwen3-30B-A3B-Instruct-2507")
+"""
+
+import logging
+import os
+from typing import Any, ClassVar, List
+
+from lobster.config.providers.base_provider import ILLMProvider, ModelInfo
+
+logger = logging.getLogger(__name__)
+
+# Nebius AI Studio (Token Factory) API constants
+_BASE_URL = "https://api.tokenfactory.nebius.com/v1/"
+_ENV_VAR = "NEBIUS_API_KEY"
+_DEFAULT_MODEL = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+
+
+class NebiusProvider(ILLMProvider):
+    """
+    Nebius AI Studio provider — OpenAI-compatible open-weight model host.
+
+    Nebius AI Studio (Token Factory) accepts requests in OpenAI API format
+    and serves open-weight models from Qwen, DeepSeek, Moonshot, Zhipu,
+    MiniMax, Nous Research, NVIDIA, and Google. A single NEBIUS_API_KEY
+    gives access to all catalog models.
+
+    Model names use the "org/model-name" format:
+        - "Qwen/Qwen3-30B-A3B-Instruct-2507"
+        - "deepseek-ai/DeepSeek-V4-Pro"
+        - "google/gemma-3-27b-it"
+
+    Features:
+        - Static KNOWN_MODELS catalog with pricing (no network on list)
+        - No new dependencies — uses ChatOpenAI with base_url override
+        - No branding headers
+
+    Usage:
+        >>> provider = NebiusProvider()
+        >>> if not provider.is_configured():
+        ...     print("Set NEBIUS_API_KEY in .env")
+        >>> models = provider.list_models()
+        >>> llm = provider.create_chat_model("Qwen/Qwen3-30B-A3B-Instruct-2507")
+    """
+
+    # Static catalog — pricing (USD per 1M tokens) verified against Nebius.
+    KNOWN_MODELS: ClassVar[List[ModelInfo]] = [
+        ModelInfo(
+            name="Qwen/Qwen3-235B-A22B-Instruct-2507",
+            display_name="Qwen3 235B A22B Instruct",
+            description="Qwen3 flagship for general reasoning",
+            provider="nebius",
+            context_window=262144,
+            is_default=False,
+            input_cost_per_million=0.20,
+            output_cost_per_million=0.60,
+        ),
+        ModelInfo(
+            name="Qwen/Qwen3-32B",
+            display_name="Qwen3 32B",
+            description="Qwen3 generalist: multilingual and coding",
+            provider="nebius",
+            context_window=40960,
+            is_default=False,
+            input_cost_per_million=0.10,
+            output_cost_per_million=0.30,
+        ),
+        ModelInfo(
+            name="Qwen/Qwen3-30B-A3B-Instruct-2507",
+            display_name="Qwen3 30B A3B Instruct",
+            description="Versatile 30B instruct model, 262k context",
+            provider="nebius",
+            context_window=262144,
+            is_default=True,
+            input_cost_per_million=0.10,
+            output_cost_per_million=0.30,
+        ),
+        ModelInfo(
+            name="Qwen/Qwen3-Next-80B-A3B-Thinking",
+            display_name="Qwen3 Next 80B A3B Thinking",
+            description="Qwen3 thinking-optimized for multi-step reasoning",
+            provider="nebius",
+            context_window=128000,
+            is_default=False,
+            input_cost_per_million=0.15,
+            output_cost_per_million=1.20,
+        ),
+        ModelInfo(
+            name="Qwen/Qwen3.5-397B-A17B",
+            display_name="Qwen3.5 397B A17B",
+            description="Qwen3.5 MoE multimodal flagship",
+            provider="nebius",
+            context_window=262144,
+            is_default=False,
+            input_cost_per_million=0.60,
+            output_cost_per_million=3.60,
+        ),
+        ModelInfo(
+            name="moonshotai/Kimi-K2.6",
+            display_name="Kimi K2.6",
+            description="Moonshot multimodal agentic model",
+            provider="nebius",
+            context_window=262144,
+            is_default=False,
+            input_cost_per_million=0.95,
+            output_cost_per_million=4.00,
+        ),
+        ModelInfo(
+            name="moonshotai/Kimi-K2.7-Code",
+            display_name="Kimi K2.7 Code",
+            description="Moonshot code-focused reasoning model",
+            provider="nebius",
+            context_window=8000,
+            is_default=False,
+            input_cost_per_million=0.95,
+            output_cost_per_million=4.00,
+        ),
+        ModelInfo(
+            name="zai-org/GLM-5.1",
+            display_name="GLM-5.1",
+            description="Zhipu flagship multimodal bilingual model",
+            provider="nebius",
+            context_window=202752,
+            is_default=False,
+            input_cost_per_million=1.40,
+            output_cost_per_million=4.40,
+        ),
+        ModelInfo(
+            name="zai-org/GLM-5.2",
+            display_name="GLM-5.2",
+            description="Zhipu latest flagship multimodal model",
+            provider="nebius",
+            context_window=8000,
+            is_default=False,
+            input_cost_per_million=1.40,
+            output_cost_per_million=4.40,
+        ),
+        ModelInfo(
+            name="deepseek-ai/DeepSeek-V4-Pro",
+            display_name="DeepSeek V4 Pro",
+            description="DeepSeek advanced reasoning, 1M context",
+            provider="nebius",
+            context_window=1048576,
+            is_default=False,
+            input_cost_per_million=1.75,
+            output_cost_per_million=3.50,
+        ),
+        ModelInfo(
+            name="MiniMaxAI/MiniMax-M3",
+            display_name="MiniMax M3",
+            description="MiniMax 428B MoE reasoning model",
+            provider="nebius",
+            context_window=8000,
+            is_default=False,
+            input_cost_per_million=0.30,
+            output_cost_per_million=1.20,
+        ),
+        ModelInfo(
+            name="MiniMaxAI/MiniMax-M2.5",
+            display_name="MiniMax M2.5",
+            description="MiniMax agentic coding model",
+            provider="nebius",
+            context_window=196608,
+            is_default=False,
+            input_cost_per_million=0.30,
+            output_cost_per_million=1.20,
+        ),
+        ModelInfo(
+            name="NousResearch/Hermes-4-70B",
+            display_name="Hermes 4 70B",
+            description="Nous Hermes-4 compact reasoning model",
+            provider="nebius",
+            context_window=131072,
+            is_default=False,
+            input_cost_per_million=0.13,
+            output_cost_per_million=0.40,
+        ),
+        ModelInfo(
+            name="NousResearch/Hermes-4-405B",
+            display_name="Hermes 4 405B",
+            description="Nous Hermes-4 hybrid reasoning model",
+            provider="nebius",
+            context_window=131072,
+            is_default=False,
+            input_cost_per_million=1.00,
+            output_cost_per_million=3.00,
+        ),
+        ModelInfo(
+            name="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
+            display_name="Nemotron 3 Nano 30B A3B",
+            description="NVIDIA Nemotron-3 nano, low cost",
+            provider="nebius",
+            context_window=262144,
+            is_default=False,
+            input_cost_per_million=0.06,
+            output_cost_per_million=0.24,
+        ),
+        ModelInfo(
+            name="nvidia/Nemotron-3-Nano-Omni",
+            display_name="Nemotron 3 Nano Omni",
+            description="NVIDIA Nemotron-3 nano omni model",
+            provider="nebius",
+            context_window=262144,
+            is_default=False,
+            input_cost_per_million=0.06,
+            output_cost_per_million=0.24,
+        ),
+        ModelInfo(
+            name="nvidia/Nemotron-3-Ultra-550b-a55b",
+            display_name="Nemotron 3 Ultra 550B A55B",
+            description="NVIDIA Nemotron-3 ultra, 1M context",
+            provider="nebius",
+            context_window=1048576,
+            is_default=False,
+            input_cost_per_million=1.00,
+            output_cost_per_million=3.00,
+        ),
+        ModelInfo(
+            name="nvidia/nemotron-3-super-120b-a12b",
+            display_name="Nemotron 3 Super 120B A12B",
+            description="NVIDIA Nemotron-3 super model",
+            provider="nebius",
+            context_window=262144,
+            is_default=False,
+            input_cost_per_million=0.30,
+            output_cost_per_million=0.90,
+        ),
+        ModelInfo(
+            name="nvidia/Cosmos3-Super-Reasoner",
+            display_name="Cosmos3 Super Reasoner",
+            description="NVIDIA Cosmos3 reasoning model",
+            provider="nebius",
+            context_window=262144,
+            is_default=False,
+            input_cost_per_million=0.10,
+            output_cost_per_million=0.30,
+        ),
+        ModelInfo(
+            name="google/gemma-3-27b-it",
+            display_name="Gemma 3 27B IT",
+            description="Google Gemma 3 27B instruct model",
+            provider="nebius",
+            context_window=110000,
+            is_default=False,
+            input_cost_per_million=0.10,
+            output_cost_per_million=0.30,
+        ),
+    ]
+
+    @property
+    def name(self) -> str:
+        return "nebius"
+
+    @property
+    def display_name(self) -> str:
+        return "Nebius AI Studio"
+
+    def check_dependencies(self) -> None:
+        try:
+            import langchain_openai  # noqa: F401
+        except ImportError:
+            from lobster.core.component_registry import get_install_command
+
+            cmd = get_install_command("nebius", is_extra=True)
+            raise ImportError(
+                f"langchain-openai package not installed. Install with: {cmd}"
+            )
+
+    def is_configured(self) -> bool:
+        """Check if NEBIUS_API_KEY is present and non-empty."""
+        api_key = os.environ.get(_ENV_VAR)
+        return bool(api_key and api_key.strip())
+
+    def is_available(self) -> bool:
+        """Check if Nebius is accessible (equals is_configured for cloud providers)."""
+        return self.is_configured()
+
+    def get_default_model(self) -> str:
+        """Get the recommended default model."""
+        return _DEFAULT_MODEL
+
+    def list_models(self) -> List[ModelInfo]:
+        """Return the static Nebius catalog (no network call)."""
+        return list(self.KNOWN_MODELS)
+
+    def create_chat_model(
+        self,
+        model_id: str,
+        temperature: float = 1.0,
+        max_tokens: int = 4096,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Create a ChatOpenAI instance routed through Nebius AI Studio.
+
+        Uses the OpenAI-compatible API with Nebius's base URL. No branding
+        headers are attached.
+        """
+        try:
+            from langchain_openai import ChatOpenAI
+        except ImportError:
+            from lobster.core.component_registry import get_install_command
+
+            raise ImportError(
+                "langchain-openai package not installed. "
+                f"Install with: {get_install_command('langchain-openai')}"
+            )
+
+        api_key = kwargs.pop("api_key", None) or os.environ.get(_ENV_VAR)
+        if not api_key:
+            raise ValueError(
+                f"{_ENV_VAR} not found in environment. "
+                f"Set it with: export {_ENV_VAR}=..."
+            )
+
+        return ChatOpenAI(
+            model=model_id,
+            api_key=api_key,
+            base_url=_BASE_URL,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    def get_configuration_help(self) -> str:
+        return (
+            "Configure Nebius AI Studio:\n\n"
+            "1. Get an API key from Nebius AI Studio / Token Factory:\n"
+            "   https://nebius.com\n"
+            "2. Set environment variable:\n"
+            "   export NEBIUS_API_KEY=...\n\n"
+            "Or add to .env file:\n"
+            "   NEBIUS_API_KEY=...\n\n"
+            f"Default model: {_DEFAULT_MODEL}\n"
+            "Model format: org/model-name (e.g., Qwen/Qwen3-30B-A3B-Instruct-2507)\n"
+        )
+
+
+# Auto-register provider with registry
+from lobster.config.providers.registry import ProviderRegistry
+
+ProviderRegistry.register(NebiusProvider())

--- a/lobster/config/providers/registry.py
+++ b/lobster/config/providers/registry.py
@@ -181,6 +181,7 @@ class ProviderRegistry:
             ("lobster.config.providers.openai_provider", "OpenAIProvider"),
             ("lobster.config.providers.openrouter_provider", "OpenRouterProvider"),
             ("lobster.config.providers.omics_os_provider", "OmicsOSProvider"),
+            ("lobster.config.providers.nebius_provider", "NebiusProvider"),
         ]
 
         import sys

--- a/tests/unit/config/test_config_base.py
+++ b/tests/unit/config/test_config_base.py
@@ -16,7 +16,8 @@ def test_valid_providers_includes_all():
     assert "openai" in VALID_PROVIDERS
     assert "openrouter" in VALID_PROVIDERS
     assert "omics-os" in VALID_PROVIDERS
-    assert len(VALID_PROVIDERS) == 8
+    assert "nebius" in VALID_PROVIDERS
+    assert len(VALID_PROVIDERS) == 9
 
 
 def test_valid_profiles_includes_all():

--- a/tests/unit/config/test_nebius_provider.py
+++ b/tests/unit/config/test_nebius_provider.py
@@ -1,0 +1,109 @@
+"""
+Focused unit tests for the Nebius AI Studio provider.
+
+Nebius is a reduced, OpenAI-wire-compatible provider: static KNOWN_MODELS
+catalog, no live catalog fetch, no branding headers, no /auth/key probe.
+These tests therefore assert only what the Nebius provider actually does —
+they do NOT clone the OpenRouter tests (live catalog / headers / auth-key).
+"""
+
+import importlib.util
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lobster.config.constants import VALID_PROVIDERS
+from lobster.config.providers import ProviderRegistry, get_provider
+from lobster.config.providers.nebius_provider import NebiusProvider
+
+_DEFAULT_MODEL = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+_BASE_URL = "https://api.tokenfactory.nebius.com/v1/"
+
+
+def test_nebius_provider_name_and_abstractmethods():
+    """name is 'nebius' and every ILLMProvider abstractmethod is implemented."""
+    assert NebiusProvider().name == "nebius"
+    # Empty frozenset proves no ABC abstractmethod is left unimplemented,
+    # so instantiation/registration cannot raise TypeError.
+    assert NebiusProvider.__abstractmethods__ == frozenset()
+
+
+def test_nebius_provider_display_name():
+    """display_name is the human-friendly Nebius label."""
+    assert NebiusProvider().display_name == "Nebius AI Studio"
+
+
+def test_nebius_is_configured_reflects_env():
+    """is_configured() tracks NEBIUS_API_KEY presence."""
+    provider = NebiusProvider()
+
+    # Key present
+    with patch.dict(os.environ, {"NEBIUS_API_KEY": "test-key"}, clear=True):
+        assert provider.is_configured()
+
+    # Key absent
+    with patch.dict(os.environ, {}, clear=True):
+        assert not provider.is_configured()
+
+
+def test_nebius_is_available_matches_configured():
+    """is_available() equals is_configured() for this cloud provider."""
+    provider = NebiusProvider()
+    with patch.dict(os.environ, {"NEBIUS_API_KEY": "test-key"}, clear=True):
+        assert provider.is_available()
+    with patch.dict(os.environ, {}, clear=True):
+        assert not provider.is_available()
+
+
+def test_nebius_get_default_model():
+    """Default model is the canonical Qwen3 30B instruct id."""
+    assert NebiusProvider().get_default_model() == _DEFAULT_MODEL
+
+
+@pytest.mark.skipif(
+    not importlib.util.find_spec("langchain_openai"),
+    reason="langchain-openai not installed",
+)
+@patch("langchain_openai.ChatOpenAI")
+def test_nebius_create_chat_model(mock_chat_openai):
+    """create_chat_model builds ChatOpenAI with Nebius base_url, no headers, no network."""
+    mock_chat_openai.return_value = MagicMock()
+
+    with patch.dict(os.environ, {"NEBIUS_API_KEY": "dummy"}, clear=True):
+        provider = get_provider("nebius")
+        provider.create_chat_model(_DEFAULT_MODEL)
+
+    mock_chat_openai.assert_called_once()
+    call_kwargs = mock_chat_openai.call_args.kwargs
+    assert call_kwargs["model"] == _DEFAULT_MODEL
+    assert call_kwargs["base_url"] == _BASE_URL
+    assert call_kwargs["api_key"] == "dummy"
+    # Nebius must NOT attach OpenRouter-style branding headers.
+    assert "default_headers" not in call_kwargs
+
+
+def test_nebius_known_models_shape():
+    """KNOWN_MODELS: exactly 20 entries, all nebius, positive input cost, single default."""
+    models = NebiusProvider.KNOWN_MODELS
+    assert len(models) == 20
+    assert all(m.provider == "nebius" for m in models)
+    assert all(m.input_cost_per_million is not None for m in models)
+    assert all(m.input_cost_per_million > 0 for m in models)
+
+    defaults = [m for m in models if m.is_default is True]
+    assert len(defaults) == 1
+    assert defaults[0].name == _DEFAULT_MODEL
+
+
+def test_nebius_list_models_returns_known_models():
+    """list_models() returns the static catalog (no network)."""
+    models = NebiusProvider().list_models()
+    assert len(models) == 20
+    assert [m.name for m in models] == [m.name for m in NebiusProvider.KNOWN_MODELS]
+
+
+def test_nebius_registered_and_valid():
+    """Provider is registered and present in VALID_PROVIDERS."""
+    assert ProviderRegistry.get("nebius") is not None
+    assert "nebius" in VALID_PROVIDERS

--- a/tests/unit/config/test_provider_system.py
+++ b/tests/unit/config/test_provider_system.py
@@ -43,7 +43,7 @@ def test_provider_registry_initialization():
     # Trigger initialization
     providers = ProviderRegistry.get_provider_names()
 
-    # Should have all 7 providers registered
+    # Should have all 9 providers registered
     assert "anthropic" in providers
     assert "bedrock" in providers
     assert "ollama" in providers
@@ -52,7 +52,8 @@ def test_provider_registry_initialization():
     assert "openai" in providers
     assert "openrouter" in providers
     assert "omics-os" in providers
-    assert len(providers) == 8
+    assert "nebius" in providers
+    assert len(providers) == 9
 
 
 def test_get_provider():


### PR DESCRIPTION
## Summary

Adds `nebius` as a first-class LLM provider so Lobster can run **open models** — Qwen, Kimi, GLM, DeepSeek, MiniMax, Nemotron, Hermes, Gemma — via **Nebius AI Studio / Token Factory**. Requested by Alejandro (@alejandro) for benchmarking.

Clones the existing **OpenRouter pattern** (`ChatOpenAI` + `base_url` override). Nebius is OpenAI-wire-compatible, so:
- ✅ **No new dependency** — reuses the existing `openai` extra (`langchain-openai`)
- ✅ **No `pyproject.toml` edit**
- ✅ **No release/tag** — runs from an editable install on this branch

## For Alejandro — how to try it

```bash
git checkout feat/nebius-provider
uv pip install -e ".[dev,transcriptomics,genomics,proteomics,research,openai]"

export NEBIUS_API_KEY=<your key>
lobster query --provider nebius --model "Qwen/Qwen3-30B-A3B-Instruct-2507" \
  --json --session-id demo "Search PubMed for a review on CRISPR base editing. Return one title + PMID."

# See all 20 available models + pricing:
lobster config list-models   # look for the nebius rows
```

Any of the 20 catalog models works via `--model <id>` (e.g. `moonshotai/Kimi-K2.6`, `zai-org/GLM-5.2`, `deepseek-ai/DeepSeek-V4-Pro`).

## What changed

| File | Change |
|---|---|
| `lobster/config/providers/nebius_provider.py` | **NEW** — `NebiusProvider`, 20-model `KNOWN_MODELS` w/ live pricing |
| `lobster/config/providers/registry.py` | register in `_provider_specs` |
| `lobster/config/providers/__init__.py` | export `NebiusProvider` |
| `lobster/config/constants.py` | `nebius` in `VALID_PROVIDERS` + display name |
| `tests/unit/config/test_nebius_provider.py` | **NEW** — 9 focused tests (no network) |
| `test_config_base.py`, `test_provider_system.py` | provider count 8 → 9 |

- **base_url:** `https://api.tokenfactory.nebius.com/v1/` (Nebius rebranded studio → Token Factory)
- **default model:** `Qwen/Qwen3-30B-A3B-Instruct-2507`
- Static catalog feeds `MODEL_PRICING` automatically (pricing pulled live from the Nebius catalog API)

## Verification

- ✅ `pytest tests/unit/config/test_nebius_provider.py` — 9 passed
- ✅ `pytest tests/unit/config` — 341 passed, 9 skipped (no regressions)
- ✅ **Live agent tool calls** through the full graph via `lobster query --provider nebius` on **Qwen3-30B**, **Kimi-K2.6**, **GLM-5.2** — all `success=True`, real PubMed results, non-zero cost, correct model in the token tracker
- ✅ Runtime contract confirmed on the wire: model id, `base_url`, auth header, well-formed tool_calls

## Notes / follow-ups

- ⚠️ The test key serves **26 models live**; the broader Nebius dashboard list 404s for some variants (e.g. Kimi-K2.5, GLM-4.7-Flash, DeepSeek-V4-Flash). `KNOWN_MODELS` holds the 20 that actually resolve. Enable more Nebius-side if needed.
- Out of scope (per plan): `lobster init` wizard support + persisted `nebius_model` config field. Runtime `--provider nebius` override is sufficient for benchmarking.