### PR TITLE
fix(dtype): correct the pandas-3 string-dtype corruption that main still carries

### DIFF
--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -111,16 +111,16 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.24'
         cache-dependency-path: lobster-tui/go.sum
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.12'
 
@@ -200,10 +200,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.12'
 
@@ -217,7 +217,7 @@ jobs:
         python -c "from lobster.version import __version__; print(f'lobster-ai {__version__} installed')"
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: build-artifacts
         path: dist/

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -59,10 +59,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -114,7 +114,7 @@ jobs:
           fi
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: test-results-${{ matrix.package }}
@@ -140,10 +140,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -197,7 +197,7 @@ jobs:
           fi
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: test-results-preset-${{ matrix.preset }}
@@ -216,10 +216,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -250,7 +250,7 @@ jobs:
           fi
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: test-results-integration
@@ -268,7 +268,7 @@ jobs:
 
     steps:
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: test-results
           pattern: test-results-*

--- a/.github/workflows/pr-validation-basic.yml
+++ b/.github/workflows/pr-validation-basic.yml
@@ -23,7 +23,7 @@ jobs:
       
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
@@ -59,7 +59,7 @@ jobs:
         cat pr_analysis.md
     
     - name: Comment on PR
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const fs = require('fs');
@@ -85,12 +85,12 @@ jobs:
     
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.12
         cache: 'pip'
@@ -128,7 +128,11 @@ jobs:
       env:
         AWS_BEDROCK_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_ACCESS_KEY }}
         AWS_BEDROCK_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_SECRET_ACCESS_KEY }}
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        # ANTHROPIC_API_KEY intentionally absent: the secret does not exist, so it
+        # expanded to "" and advertised a credential this workflow never had. Both
+        # steps run -m "not real_api", and every test that touches the key injects
+        # its own fake value, so nothing here needs a real one. LLM-backed tests
+        # use the AWS_BEDROCK_* credentials above.
         NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
       run: |
         # Run focused test suite (same as ci-basic.yml for consistency)
@@ -154,7 +158,7 @@ jobs:
           -v
     
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: always()
       with:
         name: pr-test-results
@@ -174,7 +178,7 @@ jobs:
     steps:
     - name: Check for Go TUI changes
       id: changes
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -191,7 +195,7 @@ jobs:
 
     - name: Set up Go
       if: steps.detect.outputs.has_changes == 'true'
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.24'
         cache-dependency-path: lobster-tui/go.sum
@@ -230,12 +234,12 @@ jobs:
     
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.12
     
@@ -269,12 +273,12 @@ jobs:
     
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.12
         cache: 'pip'
@@ -288,7 +292,11 @@ jobs:
       env:
         AWS_BEDROCK_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_ACCESS_KEY }}
         AWS_BEDROCK_SECRET_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_SECRET_ACCESS_KEY }}
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        # ANTHROPIC_API_KEY intentionally absent: the secret does not exist, so it
+        # expanded to "" and advertised a credential this workflow never had. Both
+        # steps run -m "not real_api", and every test that touches the key injects
+        # its own fake value, so nothing here needs a real one. LLM-backed tests
+        # use the AWS_BEDROCK_* credentials above.
         NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
       run: |
         if [ -d "tests/integration" ]; then
@@ -304,7 +312,7 @@ jobs:
         fi
     
     - name: Upload extended test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: always()
       with:
         name: extended-test-results
@@ -322,7 +330,7 @@ jobs:
     
     steps:
     - name: Generate PR status summary
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const getIcon = (result) => {

--- a/.github/workflows/public-release.yml
+++ b/.github/workflows/public-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Extract version
       id: version
@@ -37,7 +37,7 @@ jobs:
         echo "Building release for version: $VERSION"
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.12'
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -56,10 +56,10 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       is_test: ${{ steps.version.outputs.is_test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -142,15 +142,15 @@ jobs:
             path: "packages/lobster-drug-discovery"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "0.6.0"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -169,7 +169,7 @@ jobs:
           twine check ${{ matrix.package.path }}/dist/*
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist-${{ matrix.package.name }}
           path: ${{ matrix.package.path }}/dist/
@@ -229,11 +229,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-ai
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -252,11 +252,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-transcriptomics
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -274,11 +274,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-research
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -296,11 +296,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-visualization
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -318,11 +318,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-vector
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -340,11 +340,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-proteomics
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -362,11 +362,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-genomics
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -385,11 +385,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-metabolomics
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -411,11 +411,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-metadata
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -433,11 +433,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-ml
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -455,11 +455,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-structural-viz
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -477,11 +477,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-lobster-drug-discovery
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate-version.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -523,12 +523,12 @@ jobs:
           sudo apt-get install -y -qq build-essential python3-dev
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Test core installation from TestPyPI
         run: |
@@ -701,7 +701,7 @@ jobs:
         run: sleep 60
 
       - name: Dispatch to lobster-cloud
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.LOBSTER_CLOUD_DEPLOY_TOKEN }}
           repository: the-omics-os/lobster-cloud

--- a/.github/workflows/publish-tui.yml
+++ b/.github/workflows/publish-tui.yml
@@ -46,7 +46,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       is_test: ${{ steps.version.outputs.is_test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Extract and validate version
         id: version
@@ -110,16 +110,16 @@ jobs:
             wheel_plat: macosx_10_16_x86_64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
           cache-dependency-path: lobster-tui/go.sum
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -167,14 +167,14 @@ jobs:
           done
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tui-wheel-${{ matrix.platform }}
           path: packages/lobster-ai-tui/dist/*.whl
           retention-days: 7
 
       - name: Upload raw binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tui-binary-${{ matrix.platform }}
           path: lobster-tui/lobster-tui
@@ -195,7 +195,7 @@ jobs:
       contents: read
     steps:
       - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: tui-wheel-*
           path: dist/
@@ -205,7 +205,7 @@ jobs:
         run: ls -lh dist/
 
       - name: Publish to PyPI/TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: ${{ needs.validate.outputs.is_test == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
@@ -224,7 +224,7 @@ jobs:
       contents: write
     steps:
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: tui-binary-*
           path: binaries/
@@ -244,7 +244,7 @@ jobs:
           cat checksums-tui-${VERSION}.txt
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: release-assets/*
           tag_name: v${{ needs.validate.outputs.version }}

--- a/lobster/agents/graph.py
+++ b/lobster/agents/graph.py
@@ -140,7 +140,9 @@ def _get_parent_agent(agent_name: str, worker_agents: Dict) -> Optional[str]:
     return None
 
 
-async def _invoke_and_store(agent, agent_name: str, task_description: str, store) -> str:
+async def _invoke_and_store(
+    agent, agent_name: str, task_description: str, store
+) -> str:
     """Shared invoke pipeline for all delegation tools.
 
     Constructs config for callback attribution, invokes the agent, extracts
@@ -675,6 +677,66 @@ def _build_graph_metadata(
     return metadata
 
 
+# Packages whose resolved version changes analysis behaviour or breaks imports.
+_OBSERVED_DEPENDENCIES = (
+    "lobster-ai",
+    "anndata",
+    "pandas",
+    "numpy",
+    "scanpy",
+    "setuptools",
+    "sgkit",
+)
+
+_dependency_versions_logged = False
+
+
+def _log_dependency_versions() -> None:
+    """Emit the resolved scientific stack once per process.
+
+    Both cloud Dockerfiles install the engine as ``git+...@main`` with no
+    constraints file and a cache-busting build arg, so every image re-resolves
+    this stack from PyPI at build time. Without this line there is no way to
+    tell, from outside a running container, which versions it actually got.
+
+    ``pkg_resources`` presence is tracked because setuptools >=82 removed it and
+    sgkit imports it at module load — that combination silently disables GWAS.
+    """
+    global _dependency_versions_logged
+
+    # Set the flag before doing the work: this is diagnostics, and a failure here
+    # must never re-run per session or block graph construction.
+    if _dependency_versions_logged:
+        return
+    _dependency_versions_logged = True
+
+    try:
+        import importlib.metadata as importlib_metadata
+        import importlib.util
+        import sys as _sys
+
+        parts = [
+            f"python=={_sys.version_info.major}.{_sys.version_info.minor}.{_sys.version_info.micro}"
+        ]
+        for name in _OBSERVED_DEPENDENCIES:
+            try:
+                parts.append(f"{name}=={importlib_metadata.version(name)}")
+            except Exception:
+                parts.append(f"{name}=absent")
+
+        # find_spec does not execute the module, so this does not itself trigger
+        # the pkg_resources deprecation warning.
+        try:
+            has_pkg_resources = importlib.util.find_spec("pkg_resources") is not None
+        except Exception:
+            has_pkg_resources = False
+        parts.append(f"pkg_resources={'present' if has_pkg_resources else 'ABSENT'}")
+
+        logger.info("Resolved dependency stack: %s", " ".join(parts))
+    except Exception as exc:  # pragma: no cover - diagnostics must never break startup
+        logger.debug("Could not report dependency versions: %s", exc)
+
+
 def create_bioinformatics_graph(
     data_manager: DataManagerV2,
     checkpointer: InMemorySaver = None,
@@ -724,6 +786,8 @@ def create_bioinformatics_graph(
         config = {"recursion_limit": 1000, ...}
         graph.invoke(input, config)
     """
+    _log_dependency_versions()
+
     # Auto-detect subscription tier if not provided
     if subscription_tier is None:
         try:

--- a/lobster/core/adapters/metabolomics_adapter.py
+++ b/lobster/core/adapters/metabolomics_adapter.py
@@ -17,6 +17,7 @@ import pandas as pd
 from lobster.core.adapters.base import BaseAdapter
 from lobster.core.interfaces.validator import ValidationResult
 from lobster.core.schemas.metabolomics import MetabolomicsSchema
+from lobster.core.utils.dtype_guards import is_text_dtype
 
 logger = logging.getLogger(__name__)
 
@@ -255,10 +256,14 @@ class MetabolomicsAdapter(BaseAdapter):
             col_lower = str(col).lower()
             if any(pattern in col_lower for pattern in metadata_patterns):
                 metadata_cols.append(col)
-            elif df[col].dtype == "object" and not self._is_numeric_string_column(
+            elif is_text_dtype(df[col]) and not self._is_numeric_string_column(
                 df[col]
             ):
-                # Non-numeric string columns are likely metadata
+                # Non-numeric text columns are likely metadata. Test the dtype
+                # semantically via is_text_dtype (object incl. object-with-NaN,
+                # StringDtype, and the pandas-3 str dtype); a bare ``== "object"``
+                # misses the string dtypes, leaving a text column classified as
+                # intensity and silently coerced to all-NaN by pd.to_numeric.
                 metadata_cols.append(col)
 
         # Intensity columns are the remaining ones
@@ -277,8 +282,14 @@ class MetabolomicsAdapter(BaseAdapter):
         return intensity_df, metadata_df
 
     def _is_numeric_string_column(self, series: pd.Series) -> bool:
-        """Check if a string column contains numeric values."""
-        if series.dtype != "object":
+        """Check if a text column actually holds numeric values.
+
+        Uses ``is_text_dtype`` (object incl. object-with-NaN, StringDtype,
+        pandas-3 str) rather than ``dtype == "object"`` so a numeric-encoded
+        ``string``/``str`` column is still recognized as intensity data, not
+        routed to metadata.
+        """
+        if not is_text_dtype(series):
             return False
 
         # Try to convert a sample to numeric

--- a/lobster/core/adapters/proteomics_adapter.py
+++ b/lobster/core/adapters/proteomics_adapter.py
@@ -17,6 +17,7 @@ import pandas as pd
 from lobster.core.adapters.base import BaseAdapter
 from lobster.core.interfaces.validator import ValidationResult
 from lobster.core.schemas.proteomics import ProteomicsSchema
+from lobster.core.utils.dtype_guards import boolean_flag_mask, is_text_dtype
 
 logger = logging.getLogger(__name__)
 
@@ -351,10 +352,14 @@ class ProteomicsAdapter(BaseAdapter):
             col_lower = str(col).lower()
             if any(pattern in col_lower for pattern in metadata_patterns):
                 metadata_cols.append(col)
-            elif df[col].dtype == "object" and not self._is_numeric_string_column(
+            elif is_text_dtype(df[col]) and not self._is_numeric_string_column(
                 df[col]
             ):
-                # Non-numeric string columns are likely metadata
+                # Non-numeric text columns are likely metadata. Test the dtype
+                # semantically via is_text_dtype (object incl. object-with-NaN,
+                # StringDtype, and the pandas-3 str dtype); a bare ``== "object"``
+                # misses the string dtypes, leaving a text column classified as
+                # intensity and silently coerced to all-NaN by pd.to_numeric.
                 metadata_cols.append(col)
 
         # Intensity columns are the remaining ones
@@ -373,8 +378,14 @@ class ProteomicsAdapter(BaseAdapter):
         return intensity_df, metadata_df
 
     def _is_numeric_string_column(self, series: pd.Series) -> bool:
-        """Check if a string column contains numeric values."""
-        if series.dtype != "object":
+        """Check if a text column actually holds numeric values.
+
+        Uses ``is_text_dtype`` (object incl. object-with-NaN, StringDtype,
+        pandas-3 str) rather than ``dtype == "object"`` so a numeric-encoded
+        ``string``/``str`` column is still recognized as intensity data, not
+        routed to metadata.
+        """
+        if not is_text_dtype(series):
             return False
 
         # Try to convert a sample to numeric
@@ -703,7 +714,10 @@ class ProteomicsAdapter(BaseAdapter):
         # Contaminant and reverse metrics
         if "is_contaminant" in adata.var.columns:
             try:
-                contaminant_sum = int(adata.var["is_contaminant"].astype(bool).sum())
+                # boolean_flag_mask, not astype(bool): a string flag column
+                # ('+'/''/'0'/'False') would otherwise count every non-empty
+                # value as a contaminant and inflate the reported total.
+                contaminant_sum = int(boolean_flag_mask(adata.var["is_contaminant"]).sum())
             except (TypeError, ValueError):
                 contaminant_sum = 0
             metrics["contaminant_proteins"] = contaminant_sum
@@ -714,7 +728,7 @@ class ProteomicsAdapter(BaseAdapter):
         if "is_reverse" in adata.var.columns:
             try:
                 metrics["reverse_hits"] = int(
-                    adata.var["is_reverse"].astype(bool).sum()
+                    boolean_flag_mask(adata.var["is_reverse"]).sum()
                 )
             except (TypeError, ValueError):
                 metrics["reverse_hits"] = 0

--- a/lobster/core/backends/h5ad_backend.py
+++ b/lobster/core/backends/h5ad_backend.py
@@ -272,7 +272,14 @@ class H5ADBackend(BaseBackend):
                             f"Sanitized column '{col}' - converted None to 'NA'"
                         )
 
-                # Step 4: Handle mixed-type columns (object dtype)
+                # Step 4: Handle mixed-type columns (object dtype only).
+                # Intentionally NOT broadened to pandas-3 ``str`` / StringDtype:
+                # the single-type branch below calls ``pd.to_numeric`` and would
+                # rewrite numeric-looking string IDs (e.g. "001" -> 1, losing the
+                # leading zero). pandas-3 str columns are already natively
+                # H5AD-writable, so routing them here corrupts identifiers for no
+                # benefit. (The same coercion is a latent bug for object ID
+                # columns; fixing it conservatively is a separate change.)
                 if df[col].dtype == "object":
                     # Check if column has multiple types
                     non_null_values = df[col].dropna()

--- a/lobster/core/schemas/genomics.py
+++ b/lobster/core/schemas/genomics.py
@@ -584,6 +584,7 @@ def _validate_variant_positions(adata) -> "ValidationResult":
 def _validate_vcf_fields(adata) -> "ValidationResult":
     """Validate VCF-specific fields."""
     from lobster.core.interfaces.validator import ValidationResult
+    from lobster.core.utils.dtype_guards import is_text_dtype
 
     result = ValidationResult()
 
@@ -599,7 +600,7 @@ def _validate_vcf_fields(adata) -> "ValidationResult":
         ref_alleles = adata.var["REF"]
         # Check if REF alleles are valid (A, C, G, T, N)
         valid_bases = {"A", "C", "G", "T", "N"}
-        if ref_alleles.dtype == "object":
+        if is_text_dtype(ref_alleles):
             invalid_ref = sum(
                 not all(base in valid_bases for base in str(allele))
                 for allele in ref_alleles
@@ -613,7 +614,7 @@ def _validate_vcf_fields(adata) -> "ValidationResult":
     if "ALT" in adata.var.columns:
         alt_alleles = adata.var["ALT"]
         # Check if ALT alleles are valid
-        if alt_alleles.dtype == "object":
+        if is_text_dtype(alt_alleles):
             invalid_alt = sum(
                 not all(base in valid_bases for base in str(allele))
                 for allele in alt_alleles

--- a/lobster/core/schemas/metagenomics.py
+++ b/lobster/core/schemas/metagenomics.py
@@ -675,6 +675,7 @@ class MetagenomicsSchema:
 def _validate_taxonomy(adata) -> "ValidationResult":
     """Validate taxonomic hierarchy consistency and completeness."""
     from lobster.core.interfaces.validator import ValidationResult
+    from lobster.core.utils.dtype_guards import is_text_dtype
 
     result = ValidationResult()
 
@@ -702,7 +703,7 @@ def _validate_taxonomy(adata) -> "ValidationResult":
 
     # Check for "Unassigned" or "Unknown" entries
     for level in present_levels:
-        if adata.var[level].dtype == "object":
+        if is_text_dtype(adata.var[level]):
             unassigned = (
                 adata.var[level]
                 .str.contains("unassigned|unknown", case=False, na=False)
@@ -814,8 +815,12 @@ def _validate_sequences(adata) -> "ValidationResult":
 
     # Check for chimeras if flag is present
     if "is_chimera" in adata.var.columns:
+        from lobster.core.utils.dtype_guards import boolean_flag_mask
+
         try:
-            chimeras = int(adata.var["is_chimera"].astype(bool).sum())
+            # boolean_flag_mask, not astype(bool): a string flag would count
+            # every non-empty value as a chimera and inflate the total.
+            chimeras = int(boolean_flag_mask(adata.var["is_chimera"]).sum())
         except (TypeError, ValueError):
             chimeras = 0
         if chimeras > 0:

--- a/lobster/core/schemas/proteomics.py
+++ b/lobster/core/schemas/proteomics.py
@@ -558,8 +558,12 @@ def _validate_ms_metrics(adata) -> "ValidationResult":
 
     # Check for contaminants
     if "is_contaminant" in adata.var.columns:
+        from lobster.core.utils.dtype_guards import boolean_flag_mask
+
         try:
-            contaminants = int(adata.var["is_contaminant"].astype(bool).sum())
+            # boolean_flag_mask, not astype(bool): a string flag column would
+            # count every non-empty value and inflate the contaminant total.
+            contaminants = int(boolean_flag_mask(adata.var["is_contaminant"]).sum())
         except (TypeError, ValueError):
             contaminants = 0
         contaminant_pct = (contaminants / len(adata.var)) * 100

--- a/lobster/core/schemas/transcriptomics.py
+++ b/lobster/core/schemas/transcriptomics.py
@@ -1036,9 +1036,16 @@ def _validate_gene_symbols(adata) -> "ValidationResult":
         if missing > 0:
             result.add_warning(f"{missing} missing gene symbols")
 
-        # Basic format check (starts with letter)
-        if symbols.dtype == "object":
-            invalid_format = ~symbols.str.match(r"^[A-Za-z]", na=False).sum()
+        # Basic format check (starts with letter). Test the dtype semantically:
+        # is_text_dtype covers object (incl. object-with-NaN), StringDtype, and
+        # the pandas-3 str dtype, whereas `== "object"` silently skips the check
+        # under pandas 3 (and is_string_dtype alone would skip object-with-NaN).
+        from lobster.core.utils.dtype_guards import is_text_dtype
+
+        if is_text_dtype(symbols):
+            # Parenthesize before .sum(): ``~series.sum()`` would bit-invert the
+            # scalar count (always negative, so the warning never fires).
+            invalid_format = (~symbols.str.match(r"^[A-Za-z]", na=False)).sum()
             if invalid_format > 0:
                 result.add_warning(f"{invalid_format} gene symbols with unusual format")
 

--- a/lobster/core/utils/dtype_guards.py
+++ b/lobster/core/utils/dtype_guards.py
@@ -1,0 +1,111 @@
+"""Semantic dtype predicates for pandas 2/3 compatibility.
+
+Historically, code across the engine asked "is this column textual?" by testing
+``series.dtype == object``. That is a type-identity check standing in for a
+semantic question, and it breaks in two directions:
+
+* It misses ``StringDtype`` (``"string"``, the pandas-2 opt-in) and the inferred
+  ``str`` dtype that pandas 3 produces by default (PDEP-14). A string-typed flag
+  column then slips past the guard and, in the proteomics filters, reaches
+  ``astype(bool)`` — where every non-empty token, including ``"0"`` and
+  ``"False"``, becomes ``True`` and ``adata[:, ~mask]`` empties the matrix.
+
+This module is the single, tested home for the replacement predicates so the
+same fix is not re-derived (and re-broken) in six places. ``core`` owns it;
+packages import from here.
+
+Note on ``is_string_dtype`` alone: it is **False** for an ``object`` Series that
+contains any non-string element (``NaN``, mixed types) — verified under pandas
+2.3.3 and 3.0.5. So it is *not* a drop-in replacement for ``== object``: using
+it by itself silently skips object columns with missing values, which are
+common. Use :func:`is_text_dtype`, which also accepts plain ``object``.
+"""
+from __future__ import annotations
+
+import pandas as pd
+from pandas.api import types as pdt
+
+# MaxQuant-style presence flags ("+" means yes); matched case-insensitively.
+_FLAG_TRUE_TOKENS = frozenset({"+", "true", "1", "yes"})
+
+
+def is_text_dtype(obj) -> bool:
+    """True for columns that may hold text: ``object`` (including
+    object-with-NaN and mixed-type object), pandas ``StringDtype``, and the
+    pandas-3 ``str`` dtype. Accepts a Series, Index, array, or dtype.
+
+    This is the faithful replacement for ``dtype == "object"``: it preserves the
+    old object-column behavior *and* additionally recognizes the real string
+    dtypes that ``== object`` missed. ``is_string_dtype`` alone would drop
+    object columns that contain missing values.
+    """
+    return pdt.is_object_dtype(obj) or pdt.is_string_dtype(obj)
+
+
+def boolean_flag_mask(col: pd.Series) -> pd.Series:
+    """Normalize a presence/absence flag column (``is_contaminant``,
+    ``is_reverse``, ``is_chimera``, ``qc_pass`` …) to a boolean mask, routing on
+    the *meaning* of the dtype rather than on ``dtype == object``.
+
+    Flag columns arrive in many encodings depending on the writer and on the
+    pandas/anndata versions that round-tripped the artifact: genuine ``bool``,
+    numeric ``0``/``1``, text tokens (``+``, ``True``, ``1``, ``yes``), and
+    categorical wrappers around any of those. Truthy ⇔ ``+`` / ``true`` (any
+    case) / ``1`` / ``yes`` for text, any nonzero for numeric, ``True`` for
+    bool; missing (``NaN``/``NA``) is never flagged.
+
+    Verified correct — and free of downcast ``FutureWarning``s — under pandas
+    2.3.3 and 3.0.5.
+    """
+
+    def _from_text(series: pd.Series) -> pd.Series:
+        # object / StringDtype / pandas-3 str: fillna("") does not downcast.
+        return (
+            series.fillna("").astype(str).str.strip().str.lower().isin(_FLAG_TRUE_TOKENS)
+        )
+
+    def _from_numeric(series: pd.Series) -> pd.Series:
+        # Missing -> not flagged; any nonzero -> flagged. Coerce to float first
+        # so fillna(0) never lands in a bool/int dtype that would reject it.
+        # Flags are real-valued: a complex column's imaginary part is dropped by
+        # the float cast (with a ComplexWarning), so a purely-imaginary value
+        # reads as 0 — acceptable, since flag columns are never complex.
+        return (
+            pd.to_numeric(series, errors="coerce").astype("float64").fillna(0.0).ne(0.0)
+        )
+
+    def _from_bool(series: pd.Series) -> pd.Series:
+        # Operate in nullable-boolean space to avoid the object-dtype downcast
+        # warning that plain ``object.fillna(False)`` raises.
+        return series.astype("boolean").fillna(False).astype(bool)
+
+    # Categorical hides the value type on the flat predicates (a categorical of
+    # ints reports neither numeric nor string), so decide from the category
+    # dtype and operate on a NaN-safe object materialization.
+    if isinstance(col.dtype, pd.CategoricalDtype):
+        categories_dtype = col.cat.categories.dtype
+        values = col.astype(object)
+        if pdt.is_bool_dtype(categories_dtype):
+            return _from_bool(values)
+        if pdt.is_numeric_dtype(categories_dtype):
+            return _from_numeric(values)
+        return _from_text(values)
+
+    # bool must precede numeric: is_numeric_dtype is True for bool dtypes.
+    if pdt.is_bool_dtype(col):
+        return _from_bool(col)
+    if pdt.is_numeric_dtype(col):
+        return _from_numeric(col)
+    # Pure string dtypes (object-all-str, StringDtype, pandas-3 str).
+    if pdt.is_string_dtype(col):
+        return _from_text(col)
+
+    # Remaining: object-with-NaN, or object holding python numbers / mixed types
+    # (is_string_dtype is False for these). Prefer numeric when every
+    # non-missing value is numeric-coercible; otherwise treat as text tokens.
+    # Never fall through to astype(bool).
+    coerced = pd.to_numeric(col, errors="coerce")
+    non_missing = col.notna()
+    if non_missing.sum() == 0 or bool((coerced.notna() | ~non_missing).all()):
+        return _from_numeric(col)
+    return _from_text(col)

--- a/lobster/services/data_access/geo/parser.py
+++ b/lobster/services/data_access/geo/parser.py
@@ -590,8 +590,14 @@ class GEOParser:
                 # Convert to pandas for downstream compatibility
                 df = df_polars.to_pandas()
 
-                # Set first column as index if it looks like gene/feature names
-                if df.shape[1] > 1 and df.iloc[:, 0].dtype == "object":
+                # Set first column as index if it looks like gene/feature names.
+                # Test the dtype semantically via is_text_dtype (object incl.
+                # object-with-NaN, StringDtype, and the pandas-3 str dtype that
+                # Polars->pandas can produce); `== "object"` would skip promotion
+                # under pandas 3.
+                from lobster.core.utils.dtype_guards import is_text_dtype
+
+                if df.shape[1] > 1 and is_text_dtype(df.iloc[:, 0]):
                     df = df.set_index(df.columns[0])
 
                 logger.debug(f"Successfully parsed with Polars: {df.shape}")

--- a/lobster/tools/knowledgebase_tools.py
+++ b/lobster/tools/knowledgebase_tools.py
@@ -587,8 +587,10 @@ def create_summarize_modality_tool(data_manager: DataManagerV2):
                             f"  - Mean sample call rate: {adata.obs['call_rate'].mean():.4f}"
                         )
                     if "qc_pass" in adata.var.columns:
+                        from lobster.core.utils.dtype_guards import boolean_flag_mask
+
                         try:
-                            n_pass = int(adata.var["qc_pass"].astype(bool).sum())
+                            n_pass = int(boolean_flag_mask(adata.var["qc_pass"]).sum())
                         except (TypeError, ValueError):
                             n_pass = 0
                         lines.append(

--- a/lobster/utils/logger.py
+++ b/lobster/utils/logger.py
@@ -1,68 +1,124 @@
 """
 Logging configuration for the application.
 
-This module sets up consistent logging across all components of the application,
-making it easier to track events and debug issues.
+Lobster attaches at most **one** handler, on the ``lobster`` namespace logger,
+and never disables propagation. That lets whichever process hosts the engine own
+its log output — the CLI's ConsoleManager, a uvicorn/FastAPI worker, pytest —
+while a bare script still gets readable output with zero setup.
+
+Two consequences worth knowing:
+
+1. Module loggers are left at ``NOTSET`` so they inherit from the ``lobster``
+   namespace logger. One ``LOBSTER_LOG_LEVEL`` (or one ``setLevel`` on
+   ``logging.getLogger("lobster")``) therefore controls the whole engine,
+   including the ~131 modules that call ``logging.getLogger(__name__)``
+   directly instead of going through :func:`get_logger`.
+2. Records propagate to the root logger, so a host that calls
+   ``logging.basicConfig()`` before importing the engine captures them.
 """
 
 import logging
+import os
 import sys
+import threading
+
+_NAMESPACE = "lobster"
+
+# Unset LOBSTER_LOG_LEVEL keeps the historical behaviour (engine modules emit
+# INFO). Setting it explicitly is what makes it a real knob — before this module
+# was consolidated, get_logger hardcoded INFO per module and the variable only
+# ever moved the root/Rich level, so it could not quieten the engine at all.
+_DEFAULT_LEVEL = logging.INFO
+
+_LEVEL_NAMES = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "WARN": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+
+_configure_lock = threading.Lock()
+_namespace_configured = False
 
 
-def setup_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+class _FallbackHandler(logging.StreamHandler):
+    """Stream handler that stands down once the host configures root logging.
+
+    The stand-down cannot be decided at import time. ``lobster/cli.py`` imports
+    engine modules — which call :func:`get_logger` — at lines 70-290, but only
+    installs the RichHandler on root at ``cli.py:293``. An import-time check
+    would see a bare root, attach this handler, and then double-print every
+    record once Rich arrives. Deciding per-record is order-independent, so it
+    also covers any other host that configures root after importing the engine.
     """
-    Configure a logger with consistent formatting.
 
-    Handles two scenarios:
-    1. CLI usage: ConsoleManager sets up RichHandler on root logger.
-       We detect this and let logs propagate to root (single output).
-    2. Direct usage: No RichHandler on root. We add our own StreamHandler
-       and disable propagation to prevent duplicate output.
+    def emit(self, record: logging.LogRecord) -> None:
+        # Root's own handlers, not hasHandlers(): the latter walks up from this
+        # logger and would count this handler itself.
+        if logging.getLogger().handlers:
+            return
+        super().emit(record)
+
+
+def _resolve_level() -> int:
+    """Resolve the engine-wide log level from ``LOBSTER_LOG_LEVEL``."""
+    return _LEVEL_NAMES.get(
+        os.environ.get("LOBSTER_LOG_LEVEL", "").strip().upper(), _DEFAULT_LEVEL
+    )
+
+
+def _configure_namespace() -> logging.Logger:
+    """Configure the ``lobster`` namespace logger exactly once per process."""
+    global _namespace_configured
+
+    namespace = logging.getLogger(_NAMESPACE)
+    if _namespace_configured:
+        return namespace
+
+    with _configure_lock:
+        if _namespace_configured:
+            return namespace
+
+        namespace.setLevel(_resolve_level())
+
+        if not any(isinstance(h, _FallbackHandler) for h in namespace.handlers):
+            handler = _FallbackHandler(sys.stdout)
+            handler.setFormatter(
+                logging.Formatter(
+                    "[%(asctime)s] %(levelname)s - [%(name)s] - %(message)s"
+                )
+            )
+            namespace.addHandler(handler)
+
+        _namespace_configured = True
+
+    return namespace
+
+
+def setup_logger(name: str, level: int = None) -> logging.Logger:
+    """
+    Get a logger that participates in the engine's shared logging setup.
 
     Args:
-        name: Name of the logger
-        level: Logging level (default: INFO)
+        name: Name of the logger. Names under the ``lobster`` namespace inherit
+            their level from it; anything else gets the resolved level set
+            directly, since it has no lobster ancestor to inherit from.
+        level: Optional explicit level for this logger only. Leave unset so the
+            logger inherits — that is what keeps one knob in control.
 
     Returns:
-        logging.Logger: Configured logger instance
+        logging.Logger: Logger instance.
     """
+    _configure_namespace()
+
     logger = logging.getLogger(name)
 
-    # Only configure if it hasn't been configured yet
-    if not logger.handlers:
+    if level is not None:
         logger.setLevel(level)
-
-        # Check if RichHandler is already configured on root logger
-        # This indicates CLI mode where ConsoleManager is active
-        root_logger = logging.getLogger()
-        has_rich_handler = False
-
-        try:
-            from rich.logging import RichHandler
-
-            has_rich_handler = any(
-                isinstance(handler, RichHandler) for handler in root_logger.handlers
-            )
-        except ImportError:
-            # RichHandler not available, proceed with standard handler
-            pass
-
-        if has_rich_handler:
-            # CLI mode: Let logs propagate to root's RichHandler
-            # No additional handler needed, propagation handles output
-            pass
-        else:
-            # Direct usage (tests, scripts): Add our own handler
-            # and disable propagation to prevent duplicate output
-            handler = logging.StreamHandler(sys.stdout)
-            formatter = logging.Formatter(
-                "[%(asctime)s] %(levelname)s - [%(name)s] - %(message)s"
-            )
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-            # CRITICAL: Disable propagation to prevent root logger's
-            # basicConfig handler from also outputting the same message
-            logger.propagate = False
+    elif name != _NAMESPACE and not name.startswith(_NAMESPACE + "."):
+        logger.setLevel(_resolve_level())
 
     return logger
 
@@ -70,8 +126,6 @@ def setup_logger(name: str, level: int = logging.INFO) -> logging.Logger:
 def get_logger(name: str) -> logging.Logger:
     """
     Get a logger with the given name.
-
-    This function retrieves an existing logger or creates a new one.
 
     Args:
         name: Name of the logger

--- a/packages/lobster-genomics/lobster/services/analysis/gwas_service.py
+++ b/packages/lobster-genomics/lobster/services/analysis/gwas_service.py
@@ -27,8 +27,20 @@ try:
 
     sg = _sg
     SGKIT_AVAILABLE = True
-except ImportError:
-    pass  # sgkit is optional for GWAS
+except ImportError as exc:
+    # Distinguish a deliberate opt-out from a broken install. Both used to be
+    # silent, which made a hard dependency break look identical to "sgkit is an
+    # optional extra and this deployment skipped it".
+    if getattr(exc, "name", None) == "sgkit":
+        logger.debug("sgkit not installed; GWAS tools unavailable.", exc_info=True)
+    else:
+        logger.warning(
+            "sgkit is installed but failed to import (missing %r); GWAS tools "
+            "will be unavailable. Known cause: setuptools >=82 removed "
+            "pkg_resources, which sgkit imports at module load.",
+            getattr(exc, "name", None),
+            exc_info=True,
+        )
 
 
 class GWASError(Exception):
@@ -221,7 +233,9 @@ class GWASService:
 
             # Compile statistics
             try:
-                n_significant = int(adata_gwas.var["gwas_significant"].astype(bool).sum())
+                n_significant = int(
+                    adata_gwas.var["gwas_significant"].astype(bool).sum()
+                )
             except (TypeError, ValueError):
                 n_significant = 0
             n_tested = valid_mask.sum()

--- a/packages/lobster-proteomics/lobster/agents/proteomics/shared_tools.py
+++ b/packages/lobster-proteomics/lobster/agents/proteomics/shared_tools.py
@@ -20,6 +20,7 @@ from lobster.agents.proteomics.config import (
 )
 from lobster.core.provenance.analysis_ir import AnalysisStep, ParameterSpec
 from lobster.core.runtime.data_manager import DataManagerV2
+from lobster.core.utils.dtype_guards import boolean_flag_mask
 from lobster.services.analysis.proteomics_analysis_service import (
     ProteomicsAnalysisService,
 )
@@ -659,25 +660,13 @@ adata = ad.AnnData(df.select_dtypes(include='number').values.astype('float32'),
                 # NaN means not a contaminant. Normalize to boolean mask.
                 if platform_config.platform_specific.get("remove_contaminants", True):
                     if "is_contaminant" in adata_filtered.var.columns:
-                        col = adata_filtered.var["is_contaminant"]
-                        if col.dtype == object or col.dtype.name == "category":
-                            mask = col.fillna("").astype(str).isin(
-                                ["+", "True", "true", "1", "yes", "Yes"]
-                            )
-                        else:
-                            mask = col.fillna(False).astype(bool)
+                        mask = boolean_flag_mask(adata_filtered.var["is_contaminant"])
                         adata_filtered = adata_filtered[:, ~mask].copy()
 
                 # MS: Remove reverse hits (same convention as contaminants)
                 if platform_config.platform_specific.get("remove_reverse_hits", True):
                     if "is_reverse" in adata_filtered.var.columns:
-                        col = adata_filtered.var["is_reverse"]
-                        if col.dtype == object or col.dtype.name == "category":
-                            mask = col.fillna("").astype(str).isin(
-                                ["+", "True", "true", "1", "yes", "Yes"]
-                            )
-                        else:
-                            mask = col.fillna(False).astype(bool)
+                        mask = boolean_flag_mask(adata_filtered.var["is_reverse"])
                         adata_filtered = adata_filtered[:, ~mask].copy()
             else:
                 # Affinity: Filter by CV (column added by external Olink/SomaScan metadata, not by Lobster tools)

--- a/packages/lobster-proteomics/lobster/services/data_access/spectronaut_parser.py
+++ b/packages/lobster-proteomics/lobster/services/data_access/spectronaut_parser.py
@@ -1143,12 +1143,14 @@ print(f"Format: {{ format_type }}, Missing: {stats['missing_percentage']:.1f}%")
             reverse_pattern, case=False, na=False, regex=True
         )
 
+        from lobster.core.utils.dtype_guards import boolean_flag_mask
+
         try:
-            n_contaminants = adata.var["is_contaminant"].astype(bool).sum()
+            n_contaminants = boolean_flag_mask(adata.var["is_contaminant"]).sum()
         except (TypeError, ValueError):
             n_contaminants = 0
         try:
-            n_reverse = adata.var["is_reverse"].astype(bool).sum()
+            n_reverse = boolean_flag_mask(adata.var["is_reverse"]).sum()
         except (TypeError, ValueError):
             n_reverse = 0
 

--- a/packages/lobster-proteomics/tests/agents/test_contaminant_reverse_dtype.py
+++ b/packages/lobster-proteomics/tests/agents/test_contaminant_reverse_dtype.py
@@ -1,0 +1,108 @@
+"""Regression tests for the contaminant / reverse-hit flag filter dtype guard.
+
+Assignment 1 (P0). The MS filters in ``shared_tools.py`` route an
+``is_contaminant`` / ``is_reverse`` flag column to a boolean mask and drop the
+flagged features (``adata[:, ~mask]``). The historical guard branched on
+``dtype == object``; a ``StringDtype`` (pandas 2 opt-in) or the pandas-3
+inferred ``str`` dtype fell through to ``astype(bool)``, where every non-empty
+token — including ``'0'`` and ``'False'`` — becomes ``True`` and ``~mask``
+empties the matrix.
+
+Every case is asserted on **features retained**, not "no exception", and runs
+under both ``pd.options.future.infer_string`` regimes via ``pandas_infer_string``
+so the vulnerable path is exercised, not just the object path.
+"""
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+
+from lobster.core.utils.dtype_guards import boolean_flag_mask
+
+
+def _col(values, encoding):
+    """Build a flag column of `values` in the requested dtype encoding.
+
+    `values` is a list over {True (flagged), False (not), None (missing)}.
+    """
+    tokens = {True: "+", False: "", None: None}
+    nums = {True: 1, False: 0, None: None}
+    if encoding == "text_plus":
+        return pd.Series([tokens[v] for v in values])
+    if encoding == "text_truefalse":
+        return pd.Series([{True: "True", False: "False", None: None}[v] for v in values])
+    if encoding == "text_10":
+        return pd.Series([{True: "1", False: "0", None: None}[v] for v in values])
+    if encoding == "string_dtype":
+        return pd.Series(pd.array([tokens[v] for v in values], dtype="string"))
+    if encoding == "bool":
+        return pd.Series([False if v is None else v for v in values], dtype=bool)
+    if encoding == "nullable_boolean":
+        return pd.Series([pd.NA if v is None else v for v in values], dtype="boolean")
+    if encoding == "numeric":
+        return pd.Series([np.nan if v is None else nums[v] for v in values], dtype="float64")
+    if encoding == "categorical_text":
+        return pd.Series(pd.Categorical([tokens[v] for v in values]))
+    if encoding == "categorical_numeric":
+        return pd.Series(pd.Categorical([nums[v] for v in values]))
+    if encoding == "categorical_bool":
+        return pd.Series(pd.Categorical([None if v is None else bool(v) for v in values]))
+    raise AssertionError(encoding)
+
+
+ENCODINGS = [
+    "text_plus", "text_truefalse", "text_10", "string_dtype", "bool",
+    "nullable_boolean", "numeric", "categorical_text", "categorical_numeric",
+    "categorical_bool",
+]
+
+
+@pytest.mark.parametrize("encoding", ENCODINGS)
+def test_flag_mask_marks_only_flagged(encoding, pandas_infer_string):
+    # pattern: flagged, not, flagged, not  -> keep (~mask) = [F, T, F, T]
+    col = _col([True, False, True, False], encoding)
+    mask = boolean_flag_mask(col)
+    assert list(mask) == [True, False, True, False], f"{encoding}: {list(mask)}"
+
+
+@pytest.mark.parametrize("encoding", ENCODINGS)
+def test_missing_is_not_flagged(encoding, pandas_infer_string):
+    if encoding == "bool":
+        pytest.skip("numpy bool cannot represent missing")
+    col = _col([True, None, False, None], encoding)
+    mask = boolean_flag_mask(col)
+    # flagged only at index 0; missing -> not flagged
+    assert list(mask) == [True, False, False, False], f"{encoding}: {list(mask)}"
+
+
+@pytest.mark.parametrize("encoding", ["string_dtype", "text_plus"])
+def test_zero_and_false_tokens_are_not_flagged(encoding, pandas_infer_string):
+    """The exact corruption case: '0' and 'False' must NOT count as flagged."""
+    col = pd.Series(pd.array(["0", "False", "+"], dtype="string")) \
+        if encoding == "string_dtype" else pd.Series(["0", "False", "+"])
+    mask = boolean_flag_mask(col)
+    assert list(mask) == [False, False, True]
+
+
+def test_categorical_without_empty_string_does_not_raise(pandas_infer_string):
+    """Old code did ``fillna("")`` on a categorical; if "" was not already a
+    category, pandas 2.3.3 raised TypeError. New code must handle it."""
+    col = pd.Series(pd.Categorical(["+", "x", "+", "x"]))  # no "" category
+    mask = boolean_flag_mask(col)
+    assert list(mask) == [True, False, True, False]
+
+
+@pytest.mark.parametrize("encoding", ["string_dtype", "text_plus", "categorical_text"])
+def test_anndata_features_retained_through_filter(encoding, pandas_infer_string):
+    """Integration: apply the exact call-site expression to a real AnnData and
+    assert the non-contaminant features survive (not a zeroed matrix)."""
+    X = np.arange(12, dtype=float).reshape(3, 4)
+    var = pd.DataFrame(index=[f"P{i}" for i in range(4)])
+    var["is_contaminant"] = _col([True, False, True, False], encoding).values
+    adata = ad.AnnData(X=X, var=var)
+
+    mask = boolean_flag_mask(adata.var["is_contaminant"])
+    kept = adata[:, ~mask].copy()
+
+    assert kept.n_vars == 2, f"{encoding}: matrix emptied to {kept.n_vars} vars"
+    assert list(kept.var_names) == ["P1", "P3"]

--- a/packages/lobster-proteomics/tests/conftest.py
+++ b/packages/lobster-proteomics/tests/conftest.py
@@ -6,8 +6,30 @@ are importable when running from the repo root with importlib mode.
 import sys
 from pathlib import Path
 
+import pandas as pd
+import pytest
+
 # __file__ = .../lobster/packages/lobster-proteomics/tests/conftest.py
 # parents[3] = .../lobster/ (repo root)
 _repo_root = str(Path(__file__).resolve().parents[3])
 if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
+
+
+@pytest.fixture(params=[False, True], ids=["infer_string_off", "infer_string_on"])
+def pandas_infer_string(request):
+    """Run a test under both pandas string-inference regimes.
+
+    The suite otherwise pins ``pd.options.future.infer_string = False`` so the
+    default string fixtures produce ``object`` dtype — which is exactly why the
+    ``StringDtype`` / pandas-3 ``str`` corruption paths never got exercised.
+    A test that must see both regimes requests this fixture: it runs once with
+    the option off (``object``) and once on (``string``/``str``), restoring the
+    previous value on teardown so no other test is affected.
+    """
+    previous = pd.options.future.infer_string
+    pd.options.future.infer_string = request.param
+    try:
+        yield request.param
+    finally:
+        pd.options.future.infer_string = previous

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,25 @@ pytest_plugins = [
 # ==============================================================================
 
 
+@pytest.fixture(params=[False, True], ids=["infer_string_off", "infer_string_on"])
+def pandas_infer_string(request):
+    """Run a test under both pandas string-inference regimes.
+
+    This module pins ``pd.options.future.infer_string = False`` at import so the
+    4800+ existing string fixtures keep producing ``object`` dtype — which is
+    also why the ``StringDtype`` / pandas-3 ``str`` corruption paths were never
+    exercised. A test that must see both regimes requests this fixture: it runs
+    once with the option off (``object``) and once on (``string``/``str``),
+    restoring the previous value on teardown so no other test is affected.
+    """
+    previous = pd.options.future.infer_string
+    pd.options.future.infer_string = request.param
+    try:
+        yield request.param
+    finally:
+        pd.options.future.infer_string = previous
+
+
 def pytest_addoption(parser):
     """Register test-suite command-line switches."""
     parser.addoption(

--- a/tests/integration/pandas3_gate/in_image_compare.py
+++ b/tests/integration/pandas3_gate/in_image_compare.py
@@ -1,0 +1,90 @@
+"""OLD-vs-NEW guard comparison — runs INSIDE the production image (pandas 3).
+
+Reproduces the live contaminant/reverse corruption with the code that is on
+production today and proves the hardened guard fixes it, in the exact runtime —
+no downgrade, no version ambiguity. Prints one row per flag encoding and exits
+nonzero if the hardened guard is ever wrong. Emits a JSON summary as the last
+line so the pytest orchestrator can assert on it.
+"""
+import json
+import sys
+
+import numpy as np
+import pandas as pd
+from pandas.api import types as pdt
+
+FLAG = [True, False, True, False]  # correct keep = {F1, F3} = 2
+
+
+def make(enc):
+    plus = {True: "+", False: ""}
+    tf = {True: "True", False: "False"}
+    tens = {True: "1", False: "0"}
+    return {
+        "text_plus": lambda: pd.Series([plus[v] for v in FLAG]),
+        "text_10": lambda: pd.Series([tens[v] for v in FLAG]),
+        "text_tf": lambda: pd.Series([tf[v] for v in FLAG]),
+        "bool": lambda: pd.Series(FLAG, dtype=bool),
+        "numeric": lambda: pd.Series([1 if v else 0 for v in FLAG], dtype="int64"),
+        "cat_text": lambda: pd.Series(pd.Categorical([plus[v] for v in FLAG])),
+    }[enc]()
+
+
+def OLD_mask(col):
+    """The guard currently on production (shared_tools.py:663/675)."""
+    if col.dtype == object or col.dtype.name == "category":
+        return col.fillna("").astype(str).isin(["+", "True", "true", "1", "yes", "Yes"])
+    return col.fillna(False).astype(bool)
+
+
+_TRUTHY = {"+", "true", "1", "yes"}
+
+
+def NEW_mask(col):
+    """Mirror of lobster.core.utils.dtype_guards.boolean_flag_mask (inlined
+    because the repo is not importable inside the production image)."""
+    def _t(s):
+        return s.fillna("").astype(str).str.strip().str.lower().isin(_TRUTHY)
+
+    def _n(s):
+        return pd.to_numeric(s, errors="coerce").astype("float64").fillna(0.0).ne(0.0)
+
+    def _b(s):
+        return s.astype("boolean").fillna(False).astype(bool)
+
+    if isinstance(col.dtype, pd.CategoricalDtype):
+        c = col.cat.categories.dtype
+        v = col.astype(object)
+        return _b(v) if pdt.is_bool_dtype(c) else _n(v) if pdt.is_numeric_dtype(c) else _t(v)
+    if pdt.is_bool_dtype(col):
+        return _b(col)
+    if pdt.is_numeric_dtype(col):
+        return _n(col)
+    if pdt.is_string_dtype(col):
+        return _t(col)
+    coerced = pd.to_numeric(col, errors="coerce")
+    non_missing = col.notna()
+    if non_missing.sum() == 0 or bool((coerced.notna() | ~non_missing).all()):
+        return _n(col)
+    return _t(col)
+
+
+rows = []
+new_wrong = 0
+old_emptied = 0
+for enc in ["text_plus", "text_10", "text_tf", "bool", "numeric", "cat_text"]:
+    col = make(enc)
+    old_keep = int((~OLD_mask(col)).sum())
+    new_keep = int((~NEW_mask(col)).sum())
+    if new_keep != 2:
+        new_wrong += 1
+    if old_keep == 0:
+        old_emptied += 1
+    rows.append({"encoding": enc, "dtype": str(col.dtype),
+                 "old_kept": old_keep, "new_kept": new_keep})
+    print(f"{enc:10s} dtype={str(col.dtype):9s} OLD={old_keep}/4 NEW={new_keep}/4")
+
+summary = {"pandas": pd.__version__, "rows": rows,
+           "new_wrong": new_wrong, "old_emptied": old_emptied}
+print("SUMMARY_JSON " + json.dumps(summary))
+sys.exit(1 if new_wrong else 0)

--- a/tests/integration/pandas3_gate/write_artifacts.py
+++ b/tests/integration/pandas3_gate/write_artifacts.py
@@ -1,0 +1,76 @@
+"""Artifact writer — runs INSIDE the production image (pandas 3 / anndata 0.13).
+
+Invoked by ``tests/integration/test_pandas3_artifact_gate.py`` via
+``docker run --network none --entrypoint /opt/venv/bin/python``. Writes
+proteomics-shaped H5AD (and Zarr) artifacts through the RAW ``write_h5ad`` path
+— the same call the three direct writers use (custom_code_execution_service.py,
+core/notebooks/exporter.py, core/runtime/data_manager.py) that bypass the
+managed backend's column sanitizer. This reproduces the pandas-3 string
+representation customer artifacts carry across a downgrade.
+
+Feature layout per file (4 vars): F0=contaminant, F1=clean, F2=contaminant,
+F3=clean. A correct reader keeps {F1, F3} and leaves the numeric matrix intact.
+"""
+import json
+import sys
+
+import numpy as np
+import pandas as pd
+import anndata as ad
+
+OUT = "/artifacts"
+FLAG = [True, False, True, False]
+
+
+def contaminant_col(encoding):
+    plus = {True: "+", False: ""}
+    tf = {True: "True", False: "False"}
+    tens = {True: "1", False: "0"}
+    builders = {
+        "text_plus": lambda: pd.Series([plus[v] for v in FLAG]),
+        "text_10": lambda: pd.Series([tens[v] for v in FLAG]),
+        "text_tf": lambda: pd.Series([tf[v] for v in FLAG]),
+        "bool": lambda: pd.Series(FLAG, dtype=bool),
+        "numeric": lambda: pd.Series([1 if v else 0 for v in FLAG], dtype="int64"),
+        "cat_text": lambda: pd.Series(pd.Categorical([plus[v] for v in FLAG])),
+        "cat_num": lambda: pd.Series(pd.Categorical([1 if v else 0 for v in FLAG])),
+    }
+    return builders[encoding]()
+
+
+ENCODINGS = ["text_plus", "text_10", "text_tf", "bool", "numeric", "cat_text", "cat_num"]
+
+manifest = {
+    "stack": {"pandas": pd.__version__, "anndata": ad.__version__},
+    "flag_rows_true": FLAG,
+    "expected_kept": ["F1", "F3"],
+    "files": [],
+}
+
+for enc in ENCODINGS:
+    X = np.arange(4 * 3, dtype=np.float64).reshape(3, 4) + 0.5  # 3 obs x 4 var
+    var = pd.DataFrame(index=[f"F{i}" for i in range(4)])
+    var["is_contaminant"] = contaminant_col(enc).values
+    var["is_reverse"] = contaminant_col(enc).values
+    var["extra_label"] = pd.Series(["batchA", "batchB", "batchA", "batchC"]).values
+    var["num_as_text"] = pd.Series(["1.5", "2.5", "3.5", "4.5"]).values
+    adata = ad.AnnData(
+        X=X, obs=pd.DataFrame(index=[f"S{i}" for i in range(3)]), var=var
+    )
+    written = {c: str(adata.var[c].dtype) for c in adata.var.columns}
+    h5ad = f"{OUT}/contam_{enc}.h5ad"
+    adata.write_h5ad(h5ad)  # RAW write — the bypass path
+    entry = {"encoding": enc, "h5ad": f"contam_{enc}.h5ad",
+             "written_var_dtypes": written}
+    try:
+        adata.write_zarr(f"{OUT}/contam_{enc}.zarr")
+        entry["zarr"] = f"contam_{enc}.zarr"
+    except Exception as e:  # noqa: BLE001
+        entry["zarr_error"] = f"{type(e).__name__}: {e}"
+    manifest["files"].append(entry)
+
+with open(f"{OUT}/manifest.json", "w") as fh:
+    json.dump(manifest, fh, indent=2)
+print(f"wrote {len(manifest['files'])} artifact sets under {OUT} "
+      f"(pandas {pd.__version__} / anndata {ad.__version__})")
+sys.exit(0)

--- a/tests/integration/test_pandas3_artifact_gate.py
+++ b/tests/integration/test_pandas3_artifact_gate.py
@@ -1,0 +1,157 @@
+"""Deploy gate: the pandas-3 cross-version artifact test (Assignment 3).
+
+Writes proteomics artifacts INSIDE the live production image
+(pandas 3.0.5 / anndata 0.13.2) via the raw ``write_h5ad`` bypass path, then
+reads them back under the candidate stack (this venv, pandas < 3 / anndata <
+0.13) and runs the hardened contaminant/reverse guard and the adapter
+metadata/intensity classifier over them.
+
+Two things are proven:
+  1. On artifacts carrying the pandas-3 string representation, the hardened
+     guard retains the correct features (and leaves the numeric matrix intact),
+     regardless of whether the downgrade-read surfaces the flag as
+     ``str`` / ``string`` / ``category`` / ``object``.
+  2. In the production runtime itself, the code currently on ``main`` empties
+     the matrix for ``'1'/'0'`` and ``'True'/'False'`` flags while the hardened
+     guard does not (``in_image_compare.py``).
+
+Requires Docker and the production image locally. Resolution order:
+``$LOBSTER_PROD_IMAGE`` → the task-def-439 digest tag that was live when this
+was authored. Skips (never fails) when neither is present, so ordinary CI —
+which has no production image — is unaffected. This is a manual pre-deploy gate,
+run on the build host that holds the image.
+
+Regenerate/inspect manually::
+
+    docker run --rm --network none --entrypoint /opt/venv/bin/python \\
+      -v "$PWD/tests/integration/pandas3_gate":/a3 -v /tmp/a3out:/artifacts \\
+      <prod-image> /a3/write_artifacts.py
+"""
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import anndata as ad
+import numpy as np
+import pytest
+from pandas.api import types as pdt
+
+from lobster.core.utils.dtype_guards import boolean_flag_mask
+from lobster.core.adapters.proteomics_adapter import ProteomicsAdapter
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+# task-def-439 image digest (live production when authored, 2026-08-15).
+_DEFAULT_IMAGE = (
+    "cdkasset-8961c8639f13856dd4f6a1b9d9101399996c0689b97e8d01360ddc663a2980fa:latest"
+)
+_GATE_DIR = Path(__file__).parent / "pandas3_gate"
+
+
+def _resolve_image():
+    if not shutil.which("docker"):
+        return None
+    for ref in (os.environ.get("LOBSTER_PROD_IMAGE"), _DEFAULT_IMAGE):
+        if not ref:
+            continue
+        probe = subprocess.run(
+            ["docker", "image", "inspect", ref],
+            capture_output=True, text=True,
+        )
+        if probe.returncode == 0:
+            return ref
+    return None
+
+
+_IMAGE = _resolve_image()
+_reason = "Docker + production image required (set $LOBSTER_PROD_IMAGE); this is a manual pre-deploy gate."
+pytestmark.append(pytest.mark.skipif(_IMAGE is None, reason=_reason))
+
+
+def _docker_python(script_name, out_dir=None):
+    mounts = ["-v", f"{_GATE_DIR}:/a3"]
+    if out_dir is not None:
+        mounts += ["-v", f"{out_dir}:/artifacts"]
+    cmd = [
+        "docker", "run", "--rm", "--network", "none",
+        "--entrypoint", "/opt/venv/bin/python",
+        *mounts, _IMAGE, f"/a3/{script_name}",
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+
+@pytest.fixture(scope="module")
+def written_artifacts(tmp_path_factory):
+    out = tmp_path_factory.mktemp("pandas3_artifacts")
+    proc = _docker_python("write_artifacts.py", out_dir=str(out))
+    assert proc.returncode == 0, f"writer failed:\n{proc.stdout}\n{proc.stderr}"
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["stack"]["pandas"].startswith("3."), (
+        f"expected a pandas-3 image, got {manifest['stack']}"
+    )
+    return out, manifest
+
+
+def test_hardened_guard_retains_features_on_prod_written_h5ad(written_artifacts):
+    out, manifest = written_artifacts
+    adapter = ProteomicsAdapter.__new__(ProteomicsAdapter)
+    expected = manifest["expected_kept"]
+
+    for entry in manifest["files"]:
+        adata = ad.read_h5ad(out / entry["h5ad"])
+        original = np.asarray(
+            adata.X.toarray() if hasattr(adata.X, "toarray") else adata.X
+        )
+
+        for flag_col in ("is_contaminant", "is_reverse"):
+            mask = boolean_flag_mask(adata.var[flag_col])
+            kept = adata[:, ~mask].copy()
+            assert list(kept.var_names) == expected, (
+                f"{entry['encoding']}/{flag_col}: kept {list(kept.var_names)} "
+                f"(persisted dtype {adata.var[flag_col].dtype})"
+            )
+            keptX = np.asarray(
+                kept.X.toarray() if hasattr(kept.X, "toarray") else kept.X
+            )
+            assert np.allclose(keptX, original[:, [1, 3]]), (
+                f"{entry['encoding']}/{flag_col}: numeric matrix altered"
+            )
+
+        # A persisted text metadata column must classify as metadata, and a
+        # numeric-encoded text column must stay intensity (never blanked).
+        assert not adapter._is_numeric_string_column(adata.var["extra_label"])
+        assert pdt.is_string_dtype(adata.var["extra_label"])
+        assert adapter._is_numeric_string_column(adata.var["num_as_text"])
+
+
+def test_hardened_guard_retains_features_on_prod_written_zarr(written_artifacts):
+    out, manifest = written_artifacts
+    zarr_entries = [e for e in manifest["files"] if "zarr" in e]
+    if not zarr_entries:
+        pytest.skip("writer produced no zarr artifacts in this image")
+    for entry in zarr_entries:
+        adata = ad.read_zarr(out / entry["zarr"])
+        mask = boolean_flag_mask(adata.var["is_contaminant"])
+        assert list(adata[:, ~mask].var_names) == manifest["expected_kept"], (
+            f"{entry['encoding']} (zarr)"
+        )
+
+
+def test_current_code_empties_matrix_in_prod_runtime():
+    """The bug is real in the prod runtime and the hardened guard fixes it."""
+    proc = _docker_python("in_image_compare.py")
+    assert proc.returncode == 0, (
+        f"hardened guard wrong in prod image:\n{proc.stdout}\n{proc.stderr}"
+    )
+    summary_line = next(
+        ln for ln in proc.stdout.splitlines() if ln.startswith("SUMMARY_JSON ")
+    )
+    summary = json.loads(summary_line[len("SUMMARY_JSON "):])
+    assert summary["pandas"].startswith("3.")
+    assert summary["new_wrong"] == 0, summary
+    # '1'/'0' and 'True'/'False' both empty the matrix under the current guard.
+    assert summary["old_emptied"] >= 2, (
+        f"expected the current guard to empty >=2 encodings, got {summary}"
+    )

--- a/tests/unit/core/adapters/test_intensity_metadata_dtype.py
+++ b/tests/unit/core/adapters/test_intensity_metadata_dtype.py
@@ -1,0 +1,82 @@
+"""Regression tests for intensity/metadata column classification dtype guard.
+
+Assignment 1 (P0). ``_separate_intensity_metadata_columns`` in the proteomics
+and metabolomics adapters classifies a column as metadata when it is textual
+and not numeric-encoded, otherwise treats it as intensity and runs
+``pd.to_numeric(errors="coerce")`` over it.
+
+The historical guard tested ``df[col].dtype == "object"``. Under pandas 3 a
+text column has dtype ``str`` (and under pandas 2 an explicit ``StringDtype``
+is ``string``), so a text metadata column that did not match a name pattern was
+NOT recognized as metadata, stayed in the intensity set, and was silently
+coerced to all-NaN. These tests assert the text column lands in metadata under
+both ``pd.options.future.infer_string`` regimes.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from lobster.core.adapters.metabolomics_adapter import MetabolomicsAdapter
+from lobster.core.adapters.proteomics_adapter import ProteomicsAdapter
+
+
+def _adapter(cls):
+    # __init__ needs schema/config wiring we don't want here; the method under
+    # test only uses self._is_numeric_string_column, which is stateless.
+    return cls.__new__(cls)
+
+
+@pytest.mark.parametrize("cls", [ProteomicsAdapter, MetabolomicsAdapter])
+def test_text_column_classified_as_metadata(cls, pandas_infer_string):
+    # "extra_col" matches no name pattern in either adapter, so classification
+    # falls to the dtype branch — exactly the path that regressed under pandas 3.
+    df = pd.DataFrame(
+        {
+            "extra_col": pd.Series(["batchA", "batchB", "batchA"]),  # real text
+            "sample_1": [10.0, 20.0, 30.0],
+            "sample_2": [1.5, 2.5, 3.5],
+            "num_as_text": pd.Series(["1.1", "2.2", "3.3"]),  # numeric-encoded
+        }
+    )
+    adapter = _adapter(cls)
+    intensity_df, metadata_df = adapter._separate_intensity_metadata_columns(df)
+
+    assert metadata_df is not None
+    assert "extra_col" in metadata_df.columns
+    # Must NOT leak into intensity (where to_numeric would blank it to all-NaN).
+    assert "extra_col" not in intensity_df.columns
+    # Numeric-encoded text is intensity and survives coercion (not all-NaN).
+    assert "num_as_text" in intensity_df.columns
+    assert not intensity_df["num_as_text"].isna().all()
+    assert {"sample_1", "sample_2"}.issubset(intensity_df.columns)
+
+
+@pytest.mark.parametrize("cls", [ProteomicsAdapter, MetabolomicsAdapter])
+def test_object_metadata_with_missing_is_not_blanked(cls, pandas_infer_string):
+    """Regression: object-dtype text with a missing value. is_string_dtype is
+    False for object-with-NaN, so an is_string_dtype-only guard would misroute
+    this to intensity and blank it; is_text_dtype keeps it as metadata."""
+    df = pd.DataFrame(
+        {
+            "extra_col": pd.Series(["batchA", None, "batchB"], dtype=object),
+            "s1": [1.0, 2.0, 3.0],
+        }
+    )
+    intensity_df, metadata_df = _adapter(cls)._separate_intensity_metadata_columns(df)
+    assert metadata_df is not None and "extra_col" in metadata_df.columns
+    assert "extra_col" not in intensity_df.columns
+
+
+@pytest.mark.parametrize("cls", [ProteomicsAdapter, MetabolomicsAdapter])
+def test_numeric_string_column_not_blanked(cls, pandas_infer_string):
+    """A column of numeric-encoded strings must become real numbers, never NaN."""
+    df = pd.DataFrame(
+        {
+            "label": pd.Series(["m1", "m2"]),
+            "abundance": pd.Series(["100.0", "200.0"]),
+        }
+    )
+    intensity_df, metadata_df = _adapter(cls)._separate_intensity_metadata_columns(df)
+    assert "abundance" in intensity_df.columns
+    assert list(intensity_df["abundance"]) == [100.0, 200.0]
+    assert metadata_df is not None and "label" in metadata_df.columns

--- a/tests/unit/core/backends/test_h5ad_backend_string_dtype.py
+++ b/tests/unit/core/backends/test_h5ad_backend_string_dtype.py
@@ -1,0 +1,44 @@
+"""The H5AD write sanitizer must not corrupt string identifier columns.
+
+``sanitize_anndata``'s object branch calls ``pd.to_numeric`` on single-type
+columns, which rewrites numeric-looking text IDs ("001" -> 1, losing the
+leading zero). That branch is gated on ``dtype == "object"`` and is deliberately
+NOT broadened to pandas-3 ``str`` / ``StringDtype``: those columns are natively
+H5AD-writable, so routing them through the coercion would corrupt identifiers
+for no benefit. These tests pin that decision (a future broadening would
+re-introduce the corruption) and confirm the object mixed-type path still
+produces a writable object.
+"""
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from lobster.core.backends.h5ad_backend import H5ADBackend
+
+
+def _adata(var: pd.DataFrame) -> ad.AnnData:
+    var.index = [f"g{i}" for i in range(len(var))]
+    return ad.AnnData(X=np.ones((2, len(var)), dtype=float), var=var)
+
+
+def test_string_id_column_is_preserved_not_coerced():
+    # StringDtype numeric-looking IDs must survive the sanitizer unchanged.
+    var = pd.DataFrame({"sample_id": pd.array(["001", "002", "003"], dtype="string")})
+    adata = _adata(var)
+    H5ADBackend.sanitize_anndata(adata)
+    assert list(adata.var["sample_id"]) == ["001", "002", "003"], (
+        f"leading-zero string IDs were corrupted: {list(adata.var['sample_id'])}"
+    )
+
+
+def test_sanitized_mixed_object_column_is_writable(tmp_path):
+    # Mixed-type object column: the sanitizer stringifies it (None -> "NA") so it
+    # can be written. Characterizes the object path the gate intentionally keeps.
+    var = pd.DataFrame({"mixed": pd.Series(["ok", 1, None], dtype=object)})
+    adata = _adata(var)
+    H5ADBackend.sanitize_anndata(adata)
+    out = tmp_path / "sanitized.h5ad"
+    adata.write_h5ad(out)  # must not raise
+    back = ad.read_h5ad(out)
+    assert back.n_vars == 3
+    assert list(back.var["mixed"]) == ["ok", "1", "NA"]

--- a/tests/unit/core/schemas/test_clinical_schema.py
+++ b/tests/unit/core/schemas/test_clinical_schema.py
@@ -9,8 +9,6 @@ Tests cover:
 - Edge cases and error handling
 """
 
-import math
-
 import pandas as pd
 import pytest
 
@@ -19,8 +17,6 @@ from lobster.core.schemas.clinical_schema import (
     RECIST_RESPONSES,
     RESPONDER_GROUP,
     RESPONSE_SYNONYMS,
-    SPECIAL_TIMEPOINTS,
-    TIMEPOINT_PATTERNS,
     ClinicalSample,
     classify_response_group,
     is_non_responder,
@@ -140,7 +136,9 @@ class TestNormalizeResponse:
         """'responder' is a GROUP, not a code - should return None with debug log."""
         import logging
 
-        caplog.set_level(logging.DEBUG)
+        # Scope to the "lobster" namespace: engine loggers inherit their level
+        # from it, so a root-only set_level no longer reaches them.
+        caplog.set_level(logging.DEBUG, logger="lobster")
         result = normalize_response("responder")
         assert result is None
         # Check debug log was emitted

--- a/tests/unit/core/schemas/test_validator_dtype_guards.py
+++ b/tests/unit/core/schemas/test_validator_dtype_guards.py
@@ -1,0 +1,85 @@
+"""Assignment 4: schema validators must run under the pandas-3 string dtype.
+
+These validators gated string-only checks on ``dtype == "object"``, which is
+False for the pandas-3 ``str`` dtype (and pandas-2 ``StringDtype``), so the
+checks silently no-op'd on exactly the data they exist to police. The fix routes
+on ``is_string_dtype``. Each test asserts the check FIRES under both string-
+inference regimes — under ``infer_string_on`` the column is ``str`` dtype, which
+is the case the old guard skipped, so a passing assertion there is the
+discriminating one.
+"""
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from lobster.core.schemas.genomics import _validate_vcf_fields
+from lobster.core.schemas.metagenomics import _validate_taxonomy
+from lobster.core.schemas.transcriptomics import _validate_gene_symbols
+
+
+def _adata(var: pd.DataFrame) -> ad.AnnData:
+    n_var = len(var)
+    X = np.ones((2, n_var), dtype=float)
+    var.index = [f"F{i}" for i in range(n_var)]
+    return ad.AnnData(X=X, var=var)
+
+
+def test_gene_symbol_format_check_fires(pandas_infer_string):
+    # two symbols do not start with a letter -> "unusual format" warning
+    adata = _adata(pd.DataFrame({"gene_symbol": ["1BAD", "GENE", "2ALSO"]}))
+    result = _validate_gene_symbols(adata)
+    assert any("unusual format" in w for w in result.warnings), result.warnings
+
+
+def test_vcf_ref_alt_base_check_fires(pandas_infer_string):
+    adata = _adata(
+        pd.DataFrame(
+            {
+                "CHROM": ["1", "2", "3"],
+                "POS": [100, 200, 300],
+                "REF": ["A", "Z", "C"],   # Z is non-standard
+                "ALT": ["G", "Q", "T"],   # Q is non-standard
+            }
+        )
+    )
+    result = _validate_vcf_fields(adata)
+    assert any("non-standard REF" in w for w in result.warnings), result.warnings
+    assert any("non-standard ALT" in w for w in result.warnings), result.warnings
+
+
+def test_taxonomy_unassigned_check_fires(pandas_infer_string):
+    # 2/3 = 66% unassigned at Genus (> 30% threshold)
+    adata = _adata(pd.DataFrame({"Genus": ["Unassigned", "unknown", "Escherichia"]}))
+    result = _validate_taxonomy(adata)
+    assert any("Unassigned" in w for w in result.warnings), result.warnings
+
+
+# --- object-with-NaN / mixed regressions (Codex findings 3-5): is_string_dtype
+# alone is False for these, so an is_string_dtype-only swap would skip them.
+
+
+def test_gene_symbol_check_fires_on_object_with_missing():
+    adata = _adata(pd.DataFrame({"gene_symbol": pd.Series(["ACTB", None, "1BAD"], dtype=object)}))
+    result = _validate_gene_symbols(adata)
+    assert any("unusual format" in w for w in result.warnings), result.warnings
+
+
+def test_vcf_check_fires_on_object_ref_with_nan():
+    adata = _adata(
+        pd.DataFrame(
+            {
+                "CHROM": ["1", "2", "3"],
+                "POS": [1, 2, 3],
+                "REF": pd.Series(["A", np.nan, "X"], dtype=object),
+                "ALT": pd.Series(["G", "T", "C"], dtype=object),
+            }
+        )
+    )
+    result = _validate_vcf_fields(adata)
+    assert any("non-standard REF" in w for w in result.warnings), result.warnings
+
+
+def test_taxonomy_check_fires_on_mixed_object():
+    adata = _adata(pd.DataFrame({"Kingdom": pd.Series(["Unknown", 5], dtype=object)}))
+    result = _validate_taxonomy(adata)
+    assert any("Unassigned" in w for w in result.warnings), result.warnings

--- a/tests/unit/core/utils/test_dtype_guards.py
+++ b/tests/unit/core/utils/test_dtype_guards.py
@@ -1,0 +1,77 @@
+"""Tests for the canonical dtype guards (lobster.core.utils.dtype_guards).
+
+Covers the two predicates that replace ``dtype == "object"`` across the engine,
+including the object-with-NaN and object-numeric edge cases that a naive
+``is_string_dtype``-only swap gets wrong.
+"""
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lobster.core.utils.dtype_guards import boolean_flag_mask, is_text_dtype
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (pd.Series(["a", "b"], dtype=object), True),
+        (pd.Series(["a", np.nan, "b"], dtype=object), True),   # object-with-NaN
+        (pd.Series([1, 2, None], dtype=object), True),         # non-string object
+        (pd.Series(pd.array(["a", "b"], dtype="string")), True),
+        (pd.Series([1.0, 2.0]), False),
+        (pd.Series([True, False]), False),
+        (pd.Series([1, 2], dtype="Int64"), False),
+        (pd.Series(pd.Categorical(["a", "b"])), True),
+        (pd.Series(pd.Categorical([1, 2])), False),
+    ],
+)
+def test_is_text_dtype(data, expected):
+    # is_text_dtype must preserve the old ``== object`` reach (incl. object with
+    # NaN/mixed) AND additionally recognize StringDtype / pandas-3 str.
+    assert is_text_dtype(data) == expected
+
+
+def _keep(col):
+    return list(~boolean_flag_mask(col))
+
+
+def test_flag_mask_object_numeric_values():
+    # object dtype holding python numbers: nonzero flagged, 0/NaN not.
+    assert list(boolean_flag_mask(pd.Series([2, 0, None], dtype=object))) == [True, False, False]
+    assert list(boolean_flag_mask(pd.Series([1.0, 0.0, np.nan], dtype=object))) == [True, False, False]
+
+
+def test_flag_mask_object_string_with_nan():
+    col = pd.Series(["+", np.nan, "0"], dtype=object)
+    assert list(boolean_flag_mask(col)) == [True, False, False]
+
+
+def test_flag_mask_all_missing_and_empty():
+    assert list(boolean_flag_mask(pd.Series([None, None], dtype=object))) == [False, False]
+    assert list(boolean_flag_mask(pd.Series([], dtype=object))) == []
+
+
+@pytest.mark.parametrize(
+    "col,expected",
+    [
+        (pd.Series(["+", "", "+", ""]), [True, False, True, False]),
+        (pd.Series(["1", "0", "1", "0"]), [True, False, True, False]),
+        (pd.Series(["True", "False", "True", "False"]), [True, False, True, False]),
+        (pd.Series(["YES", "no", "y", "Nope"]), [True, False, False, False]),  # 'y' not a token
+        (pd.Series([True, False, True, False]), [True, False, True, False]),
+        (pd.Series([True, pd.NA, False], dtype="boolean"), [True, False, False]),
+        (pd.Series([1, 0, 2, 0]), [True, False, True, False]),
+        (pd.Series([1.0, np.nan, 0.0]), [True, False, False]),
+        (pd.Series(pd.array(["+", "", "+"], dtype="string")), [True, False, True]),
+        (pd.Series(pd.Categorical(["+", "", "+"])), [True, False, True]),
+        (pd.Series(pd.Categorical([1, 0, 1])), [True, False, True]),
+        (pd.Series(pd.Categorical([True, False])), [True, False]),
+    ],
+)
+def test_flag_mask_matrix_no_downcast_warning(col, expected):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        warnings.simplefilter("error", DeprecationWarning)
+        assert list(boolean_flag_mask(col)) == expected


### PR DESCRIPTION
## Why this matters more than a normal bug fix

`main` is currently `d1983964`, and that commit carries **two independent
production-breaking defects**. Omics-OS Cloud does not run `main` — it runs a
tracked pin (`lobster-cloud/engine-pin.txt`) that deliberately points at this
branch's head, `04d833ba`, precisely because `main` is unsafe to build from.
`infrastructure/cdk_stack.py` rejects `d1983964` **by name**.

So merging this is what lets the pin move forward again instead of pointing at a
side branch.

## The two defects on `main`

**1. pandas 3 turns on `infer_string`.** Metadata columns that the engine guards
with `dtype == "object"` stop matching, so those guards evaluate False and the
columns get misrouted into numeric coercion. Downstream, matrices came back
empty. The version number is a proxy; the flag is the behaviour the guards
actually depend on, which is why the production image now asserts
`pd.options.future.infer_string is False` and not just a version range.

**2. setuptools >= 82 removed `pkg_resources`,** which `sgkit` imports at module
load. The engine catches that `ImportError` and sets `SGKIT_AVAILABLE = False`, so
**GWAS tools silently stop existing** — no traceback, no log line, no failed
health check. Five production deploys shipped that state with zero log evidence.
A pandas-only version assertion passes cleanly while setuptools 84 is installed.

Both are now gated in the consumer's image build as behavioural assertions rather
than version strings.

## What is in this branch

    474783c5  ci(security): pin third-party actions to commit SHAs; drop phantom ANTHROPIC_API_KEY
    d140f7e7  observability: consolidate engine logging under the "lobster" namespace
    04d833ba  fix(dtype): correct pandas-3 string-dtype handling that emptied matrices

## Verification

`04d833ba` is the exact commit production has been building from since
2026-08-17, so this is not untested code — it is the code that is running.
Measured on the live image after the fix: pandas 2.3.3, setuptools 81, task
definition 442, GWAS tools present again.

A follow-on PR stacks on this branch with additional dtype hardening whose four
test files execute 126 passed / 2 skipped.

## Scope note

Opened for review only. The merge is Kevin's call — nothing here merges itself,
and the cross-repo deploy dispatch that used to fire on release is being removed
in a separate PR, so merging this does **not** trigger a production deploy.
