### PR TITLE
fix(core): pandas-3 dtype follow-on hardening — and actually run its four tests

### DIFF
--- a/docs/backend/pandas3-dtype-followons.md
+++ b/docs/backend/pandas3-dtype-followons.md
@@ -1,0 +1,165 @@
+# pandas-3 dtype follow-on hardening — deferred-items registry
+
+**Status:** tracked, not yet implemented. **Owner:** engine (lobster-ga5r).
+**Created:** 2026-08-17, alongside branch `fix/pandas3-followon-hardening`.
+
+> Why this file exists: a deferred defect that is not written down is an
+> undiscovered defect with extra steps. This is the single address for the
+> pandas-3 dtype follow-on work so it does not live only in ephemeral chat.
+> (Intended for `.planning/PANDAS3_DTYPE_FIX/`, but `**/.planning/` is
+> gitignored — so it lives here, tracked, to actually survive.)
+
+## Context
+
+The pandas-3 production dtype fix shipped at engine commit
+`04d833bab92714babf1c5089feee36edab6fee82` (deployed task def 440; prod runs
+pandas 2.3.3 / anndata 0.13.2). Branch `fix/pandas3-dtype-corruption` is frozen
+at that SHA permanently as the production audit artifact — do not advance it.
+
+The **follow-on hardening batch** (`fix/pandas3-followon-hardening`) contains:
+in-scope = the categorical-string flag test closer, the h5ad object-path
+conservative coercion (`_numeric_coercion_is_lossless`), the adapter
+`_is_numeric_string_column` full-column scan, the `is_arrow_dtype` StringDtype
+fix, and the `is_object_dtype` gate refinement. Everything below is **deferred**
+out of that batch.
+
+Deferral bar: **no regression, and the authorized scope is closed** — not "every
+adjacent defect is fixed." Each item below was verified to be pre-existing at
+`04d833ba`; the follow-on batch is strictly better-or-equal on all of them.
+
+---
+
+## Deferred defects (all pre-existing at `04d833ba`, none introduced by the batch)
+
+### D1 — Identifier-vs-measurement is undecidable from value alone
+
+- **Where:** `lobster/core/backends/h5ad_backend.py` sanitize object-branch
+  (`_numeric_coercion_is_lossless`); conceptually also every value-based numeric
+  detector.
+- **Mechanism:** a canonical numeric string like `"1"` is coerced to `1` whether
+  it denotes a measurement or an identifier; `"1e3"` is preserved as a string
+  whether it denotes an ID or a measurement. No value-only predicate can
+  distinguish the two meanings. `_numeric_coercion_is_lossless` is a
+  *spelling-preservation* heuristic (it guarantees an accepted coercion never
+  changes a value's text), **not** a complete identifier classifier — its
+  docstring says so.
+- **Not a regression:** pre-fix, unconditional `pd.to_numeric` coerced `"1"` the
+  same way *and also* corrupted `"001"`/`"1e3"`; the batch preserves those. Strict
+  improvement.
+- **Real fix:** type-preserving persistence — do not infer numeric meaning for
+  values that are already strings. Numeric-string normalization belongs at
+  ingestion (adapters with an explicit intensity role) or behind an explicit
+  column-role / schema signal. Architectural; not a heuristic tweak.
+
+### D2 — `pd.to_numeric` returning an object dtype → unwritable, and the helper accepts it
+
+- **Where:** `lobster/core/backends/h5ad_backend.py` object-branch coercion (the
+  single `pd.to_numeric(df[col])` site) + `_numeric_coercion_is_lossless`.
+- **Mechanism:** for out-of-native-range integers (e.g. `"18446744073709551616"`
+  = uint64 max + 1 under pandas 3, or a mixed signed/unsigned python-int object
+  column under both versions) `pd.to_numeric` returns an **object** Series of
+  python ints. The helper sees `Integral` values, accepts the exact spelling,
+  and assigns an object Series back to `adata.var`/`obs`; anndata 0.13.2 then
+  fails to write it (`Can't implicitly convert non-string objects to strings`).
+- **Not a regression:** pre-fix unconditional `pd.to_numeric` produced the same
+  object Series and the same write failure. Not observed in api-u0z6's
+  production-corpus enumeration (8,570 objects); no known omics var/obs column
+  carries 20-digit integer identifiers.
+- **Real fix:** accept a coercion only when its result has a **non-object numeric
+  dtype**; treat an object-dtype `to_numeric` result as unusable, and have the
+  caller run the non-string stringification fallback whenever coercion is absent
+  **or** unusable (a bare helper `False` is insufficient — the current final
+  `else` leaves non-string objects untouched). Needs a caller restructure + a
+  cross-version test.
+
+### D3 — Non-string object scalars are assumed lossless (bytes, Decimal)
+
+- **Where:** `lobster/core/backends/h5ad_backend.py` `_numeric_coercion_is_lossless`,
+  the `if not isinstance(orig, str): continue` fast path.
+- **Mechanism:** the fast path skips the round-trip check for any non-string
+  object. `b"001"` → `1` (bytes identity lost; `bytes` is not `str`);
+  `Decimal("1.0000000000000000001")` → `1.0` (precision discarded).
+- **Not a regression:** pre-fix unconditional `pd.to_numeric` coerced these
+  identically. Rare in var/obs.
+- **Real fix:** restrict the fast path to scalar types whose conversion is
+  demonstrably exact (python `int`/`float`); treat `bytes`/`bytearray` as text
+  (decode + compare spelling); compare `Decimal`/`Fraction` exactly or
+  conservatively stringify. Combine with D2's non-object-result check.
+
+### D4 — Numeric-looking identifier metadata mis-classified as intensity
+
+- **Where:** `lobster/core/adapters/proteomics_adapter.py`
+  `_separate_intensity_metadata_columns` / `_is_numeric_string_column`
+  (`:349-376`, `:380-415`) and `lobster/core/adapters/metabolomics_adapter.py`
+  (`:253-280`, `:284-319`). Standardizers already recognize exact `id`
+  (`proteomics_adapter.py:431`, `metabolomics_adapter.py:335`) but classification
+  never routes the column there.
+- **Mechanism:** a column named `id` (or `sample_code`) holding `["001","002",
+  "003"]` is fully numeric-coercible, so `_is_numeric_string_column` returns
+  `True`, the column is kept as intensity, and downstream
+  `pd.to_numeric(errors="coerce")` rewrites it to `[1,2,3]` — leading zeros lost.
+- **Not a regression:** the classifier never had name-based ID detection; the
+  full-column scan (this batch) did not introduce this. Position-independent but
+  semantically wrong either way.
+- **Real fix:** recognize tokenized identifier names before value-based
+  detection — exact `id` and separator-delimited `_id`. **Do NOT use a raw
+  `"id" in name` substring:** `"lipid"` contains `"id"`, and this guard lives in
+  the **metabolomics** adapter where lipid names are the expected content, not a
+  hypothetical edge. A naive `col.lower().endswith("id")` hits `"lipid"` on the
+  first real dataset. Ambiguous numeric-text columns ultimately require the
+  explicit `intensity_columns` / schema signal (see D1); value coercibility alone
+  cannot prove meaning.
+
+---
+
+## D5 — AST lint against reintroducing type-identity dtype comparisons (engine CI)
+
+Owner: engine (this repo's CI). Replaces the removed grep. Requirements
+(hardened after the corpus review below):
+
+- Detect `ast.Compare` nodes comparing a dtype against a type-identity literal
+  (`== "object"`, `== object`, `.dtype == "category"`, etc.).
+- Allowlist keyed by **normalized node** `(file, symbol, normalized-comparison)`,
+  **not** by line number and **not** by whole symbol — suppressing a symbol hides
+  a second bad comparison next to a legitimate one.
+- Explicit **per-class policy** for tests, stubs, vendored code, generated files,
+  and code-template strings — **no blanket allowlist** for `lobster-ml` or
+  `tests/**`.
+- Stated contract for parser version and parse errors: fail-closed on an
+  unparseable file blocks every PR; skip-on-error is a hole. Choose and document.
+- **Must render or separately parse executable code-template strings** — a plain
+  AST walk silently ignores comparisons that live inside template strings (see
+  the 6 template sites below). This is the sharpest structural risk: AST produces
+  a false negative exactly where a grep would have caught it.
+
+Legitimate allowlisted entry: `h5ad_backend.py` object-gate — now
+`pd.api.types.is_object_dtype(...)`, which states intent in code and needs **no**
+allowlist entry. That is the pattern to prefer.
+
+## D6 — 15 live type-identity comparisons in `packages/lobster-ml/**`
+
+Same bug class as the shipped fix (`.values.dtype == object` and
+`.dtype == "object"` both evaluate False for a pandas-3 default string Series /
+Index). **Not live in production** — `lobster-ml` is not installed in the Cloud
+image — hence a finding, not a P0. Found by api-u0z6's Codex review.
+
+Nine live `ast.Compare` nodes:
+```
+feature_selection_service.py:1109,1334,1339
+ml_preparation_service.py:81
+ml_preprocessing_service.py:48,1155,1394
+cross_validation_service.py:658
+machine_learning_expert.py:674
+```
+
+Six inside executable code-template strings (invisible to a plain AST walk):
+```
+feature_selection_service.py:280,566,570
+ml_preparation_service.py:823
+ml_preprocessing_service.py:526
+cross_validation_service.py:271
+```
+
+Fix uses the canonical predicates in `lobster/core/utils/dtype_guards.py`
+(`is_text_dtype`, `boolean_flag_mask`) where semantic, or `is_object_dtype` where
+the question is genuinely representation-level.

--- a/lobster/core/adapters/metabolomics_adapter.py
+++ b/lobster/core/adapters/metabolomics_adapter.py
@@ -256,9 +256,7 @@ class MetabolomicsAdapter(BaseAdapter):
             col_lower = str(col).lower()
             if any(pattern in col_lower for pattern in metadata_patterns):
                 metadata_cols.append(col)
-            elif is_text_dtype(df[col]) and not self._is_numeric_string_column(
-                df[col]
-            ):
+            elif is_text_dtype(df[col]) and not self._is_numeric_string_column(df[col]):
                 # Non-numeric text columns are likely metadata. Test the dtype
                 # semantically via is_text_dtype (object incl. object-with-NaN,
                 # StringDtype, and the pandas-3 str dtype); a bare ``== "object"``
@@ -282,26 +280,41 @@ class MetabolomicsAdapter(BaseAdapter):
         return intensity_df, metadata_df
 
     def _is_numeric_string_column(self, series: pd.Series) -> bool:
-        """Check if a text column actually holds numeric values.
+        """Return True only if EVERY non-null value is numeric-coercible.
 
         Uses ``is_text_dtype`` (object incl. object-with-NaN, StringDtype,
         pandas-3 str) rather than ``dtype == "object"`` so a numeric-encoded
         ``string``/``str`` column is still recognized as intensity data, not
         routed to metadata.
+
+        Policy: the whole non-null column is tested, NOT a leading sample. The
+        prior ``.head(10)`` was position-dependent — a text value at row 11
+        after ten numeric-looking rows classified the column as intensity, and
+        the downstream ``pd.to_numeric(errors="coerce")`` then silently blanked
+        that text to NaN (the same silent-corruption class this guard exists to
+        stop). Scanning every value removes the positional bias, and the
+        fail-safe direction is deliberate: a column with ANY non-numeric token
+        is routed to metadata (text preserved, recoverable) rather than treated
+        as intensity (where the token is silently lost). A genuine intensity
+        column that encodes missingness as a non-numeric STRING marker (e.g.
+        "NA", "<LOD") therefore lands in metadata; normalizing such markers to
+        real NaN at load time is the correct upstream fix, tracked separately.
         """
         if not is_text_dtype(series):
             return False
 
-        # Try to convert a sample to numeric
-        sample = series.dropna().head(10)
-        if len(sample) == 0:
+        non_null = series.dropna()
+        if len(non_null) == 0:
             return False
 
         try:
-            pd.to_numeric(sample, errors="raise")
-            return True
+            coerced = pd.to_numeric(non_null, errors="raise")
         except (ValueError, TypeError):
             return False
+        # An empty string coerces to NaN WITHOUT raising; a column containing one
+        # is not fully numeric, so route it to metadata (preserve the token)
+        # rather than to intensity where the token would be silently lost.
+        return bool(coerced.notna().all())
 
     def _standardize_metabolomics_metadata(
         self, metadata_df: pd.DataFrame

--- a/lobster/core/adapters/proteomics_adapter.py
+++ b/lobster/core/adapters/proteomics_adapter.py
@@ -352,9 +352,7 @@ class ProteomicsAdapter(BaseAdapter):
             col_lower = str(col).lower()
             if any(pattern in col_lower for pattern in metadata_patterns):
                 metadata_cols.append(col)
-            elif is_text_dtype(df[col]) and not self._is_numeric_string_column(
-                df[col]
-            ):
+            elif is_text_dtype(df[col]) and not self._is_numeric_string_column(df[col]):
                 # Non-numeric text columns are likely metadata. Test the dtype
                 # semantically via is_text_dtype (object incl. object-with-NaN,
                 # StringDtype, and the pandas-3 str dtype); a bare ``== "object"``
@@ -378,26 +376,41 @@ class ProteomicsAdapter(BaseAdapter):
         return intensity_df, metadata_df
 
     def _is_numeric_string_column(self, series: pd.Series) -> bool:
-        """Check if a text column actually holds numeric values.
+        """Return True only if EVERY non-null value is numeric-coercible.
 
         Uses ``is_text_dtype`` (object incl. object-with-NaN, StringDtype,
         pandas-3 str) rather than ``dtype == "object"`` so a numeric-encoded
         ``string``/``str`` column is still recognized as intensity data, not
         routed to metadata.
+
+        Policy: the whole non-null column is tested, NOT a leading sample. The
+        prior ``.head(10)`` was position-dependent — a text value at row 11
+        after ten numeric-looking rows classified the column as intensity, and
+        the downstream ``pd.to_numeric(errors="coerce")`` then silently blanked
+        that text to NaN (the same silent-corruption class this guard exists to
+        stop). Scanning every value removes the positional bias, and the
+        fail-safe direction is deliberate: a column with ANY non-numeric token
+        is routed to metadata (text preserved, recoverable) rather than treated
+        as intensity (where the token is silently lost). A genuine intensity
+        column that encodes missingness as a non-numeric STRING marker (e.g.
+        "NA", "<LOD") therefore lands in metadata; normalizing such markers to
+        real NaN at load time is the correct upstream fix, tracked separately.
         """
         if not is_text_dtype(series):
             return False
 
-        # Try to convert a sample to numeric
-        sample = series.dropna().head(10)
-        if len(sample) == 0:
+        non_null = series.dropna()
+        if len(non_null) == 0:
             return False
 
         try:
-            pd.to_numeric(sample, errors="raise")
-            return True
+            coerced = pd.to_numeric(non_null, errors="raise")
         except (ValueError, TypeError):
             return False
+        # An empty string coerces to NaN WITHOUT raising; a column containing one
+        # is not fully numeric, so route it to metadata (preserve the token)
+        # rather than to intensity where the token would be silently lost.
+        return bool(coerced.notna().all())
 
     def _standardize_proteomics_metadata(
         self, metadata_df: pd.DataFrame
@@ -717,7 +730,9 @@ class ProteomicsAdapter(BaseAdapter):
                 # boolean_flag_mask, not astype(bool): a string flag column
                 # ('+'/''/'0'/'False') would otherwise count every non-empty
                 # value as a contaminant and inflate the reported total.
-                contaminant_sum = int(boolean_flag_mask(adata.var["is_contaminant"]).sum())
+                contaminant_sum = int(
+                    boolean_flag_mask(adata.var["is_contaminant"]).sum()
+                )
             except (TypeError, ValueError):
                 contaminant_sum = 0
             metrics["contaminant_proteins"] = contaminant_sum

--- a/lobster/core/backends/h5ad_backend.py
+++ b/lobster/core/backends/h5ad_backend.py
@@ -123,6 +123,50 @@ class H5ADBackend(BaseBackend):
         Note: Uses centralized sanitization utilities from lobster.core.utils.h5ad_utils
         """
 
+        def _numeric_coercion_is_lossless(original, coerced):
+            """True if numeric coercion preserves each string value's textual
+            identity, so identifier columns are never silently rewritten.
+
+            "001" -> 1 (leading zero), " 1 " -> 1 (whitespace), "1e3" -> 1000.0,
+            "+1" -> 1, "1.50" -> 1.5, and "" -> NaN all CHANGE the text and are
+            rejected (the column is kept as strings). Canonical spellings ("1",
+            "1.0", "-1", exact large integers) are accepted. Non-string originals
+            (python int/float objects) are lossless by construction.
+
+            The comparison is against the ORIGINAL string, not a stripped copy --
+            whitespace is part of identity. ``int()`` is never called on a
+            non-finite float: ``float.is_integer()`` is False for inf/nan, so
+            "inf"/"-inf" match via ``repr`` and coerce (as before) without
+            raising.
+
+            This is a conservative SPELLING-preservation heuristic, not a
+            complete identifier-vs-measurement classifier: "1" is coerced whether
+            it denotes a measurement or an ID, and "1e3" is preserved whether it
+            denotes an ID or a measurement. Value alone cannot decide that;
+            deciding it belongs at ingestion or behind a column-role signal
+            (tracked follow-on). The only guarantee here is that an accepted
+            coercion never changes a value's text.
+            """
+            from numbers import Integral
+
+            for orig, num in zip(original.tolist(), coerced.tolist()):
+                if not isinstance(orig, str):
+                    continue
+                # A string that parsed to a missing value (e.g. "") is NOT
+                # lossless -- coercing it would destroy the token.
+                if pd.isna(num):
+                    return False
+                if isinstance(num, Integral):
+                    candidates = {str(int(num))}
+                else:
+                    as_float = float(num)
+                    candidates = {repr(as_float)}
+                    if as_float.is_integer():
+                        candidates.add(str(int(as_float)))
+                if orig not in candidates:
+                    return False
+            return True
+
         # Sanitize uns (unstructured metadata) using centralized utility
         adata.uns = {
             util_sanitize_key(k, slash_replacement): util_sanitize_value(
@@ -278,9 +322,14 @@ class H5ADBackend(BaseBackend):
                 # rewrite numeric-looking string IDs (e.g. "001" -> 1, losing the
                 # leading zero). pandas-3 str columns are already natively
                 # H5AD-writable, so routing them here corrupts identifiers for no
-                # benefit. (The same coercion is a latent bug for object ID
-                # columns; fixing it conservatively is a separate change.)
-                if df[col].dtype == "object":
+                # benefit. The object-path coercion in the single-type branch
+                # below is now conservative: it coerces only when the numeric
+                # form round-trips to the original text, so object ID columns
+                # like "001" are preserved here too (see
+                # _numeric_coercion_is_lossless). is_object_dtype asks the same
+                # representation-level question as ``== "object"`` but states the
+                # intent in code and deliberately excludes StringDtype / str.
+                if pd.api.types.is_object_dtype(df[col]):
                     # Check if column has multiple types
                     non_null_values = df[col].dropna()
                     if len(non_null_values) > 0:
@@ -297,14 +346,35 @@ class H5ADBackend(BaseBackend):
                                 f"Sanitized column '{col}' - mixed types {unique_types} converted to string"
                             )
                         else:
-                            # Single type but object dtype - try numeric conversion
+                            # Single type, object dtype. Coerce to numeric ONLY
+                            # when it is lossless. This guards identifier columns:
+                            # pd.to_numeric rewrites "001" -> 1 (leading zero lost)
+                            # and "1e3" -> 1000.0, corrupting IDs. Coerce only if
+                            # every value round-trips to its original text;
+                            # otherwise keep the column as strings, which anndata
+                            # writes natively.
+                            #
+                            # Do NOT "fix" the gate above by broadening it to
+                            # str/StringDtype. pandas-3 str columns are already
+                            # H5AD-writable, and routing them through pd.to_numeric
+                            # is this exact corruption: ["001","002"] -> Int64 [1,2].
+                            # (Deploy postmortem error 11: widening the gate turned
+                            # a silent write skip into active ID corruption on every
+                            # managed write.) The revert-guard test stays red against
+                            # any widening.
                             try:
-                                # Attempt numeric conversion
-                                df[col] = pd.to_numeric(df[col])
+                                coerced = pd.to_numeric(df[col])
+                            except (ValueError, TypeError):
+                                coerced = None
+
+                            if coerced is not None and _numeric_coercion_is_lossless(
+                                df[col], coerced
+                            ):
+                                df[col] = coerced
                                 logger.debug(
                                     f"Sanitized column '{col}' - converted to numeric"
                                 )
-                            except (ValueError, TypeError):
+                            elif coerced is None:
                                 # Not numeric — check if values are non-string types
                                 # that HDF5 can't serialize (bool, int, etc.).
                                 # Do NOT use astype(str) — pandas >=2.2 re-creates
@@ -319,6 +389,9 @@ class H5ADBackend(BaseBackend):
                                     logger.debug(
                                         f"Sanitized column '{col}' - non-string object type '{first_type}' converted to string"
                                     )
+                            # else: numeric-looking strings that do NOT round-trip
+                            # (identifiers like "001") -> leave as object strings so
+                            # the identifier survives; anndata writes them natively.
 
             # Drop columns that are entirely None/NaN
             if columns_to_drop:

--- a/lobster/core/utils/h5ad_utils.py
+++ b/lobster/core/utils/h5ad_utils.py
@@ -436,18 +436,27 @@ def validate_for_h5ad(
 def is_arrow_dtype(series_or_index) -> bool:
     """Check if a pandas Series or Index uses ArrowExtensionArray.
 
-    Detects pyarrow-backed string columns introduced in pandas >=2.2.0
-    which are incompatible with anndata's H5AD/HDF5 writer.
+    Detects pandas string extension dtypes that anndata's H5AD/HDF5 writer
+    cannot serialize under ``infer_string=False``: pyarrow-backed strings
+    (pandas >=2.2.0), the ``StringDtype`` opt-in, and the pandas-3 default
+    ``str`` dtype. ``convert_arrow_to_standard`` materializes these to object.
     """
     # Check 1: Direct __arrow_array__ attribute
     if hasattr(series_or_index, "__arrow_array__"):
         return True
-    # Check 2: Check dtype string
-    if hasattr(series_or_index, "dtype"):
-        dtype_str = str(series_or_index.dtype)
+    dtype = getattr(series_or_index, "dtype", None)
+    # Check 2: pandas string EXTENSION dtypes. Catches StringDtype ("string")
+    # AND the pandas-3 default ``str`` dtype -- which stringifies as "str" (so
+    # the substring check below misses it) and whose array class is StringArray
+    # (not "Arrow"), so this isinstance check is the only one that catches it.
+    if isinstance(dtype, pd.StringDtype):
+        return True
+    # Check 3: dtype string (pyarrow-backed)
+    if dtype is not None:
+        dtype_str = str(dtype)
         if "string" in dtype_str or "pyarrow" in dtype_str:
             return True
-    # Check 3: Check underlying array type
+    # Check 4: underlying array type
     if hasattr(series_or_index, "array"):
         array_type = type(series_or_index.array).__name__
         if "Arrow" in array_type or "arrow" in array_type:

--- a/packages/lobster-proteomics/tests/agents/test_contaminant_reverse_dtype.py
+++ b/packages/lobster-proteomics/tests/agents/test_contaminant_reverse_dtype.py
@@ -12,6 +12,7 @@ Every case is asserted on **features retained**, not "no exception", and runs
 under both ``pd.options.future.infer_string`` regimes via ``pandas_infer_string``
 so the vulnerable path is exercised, not just the object path.
 """
+
 import anndata as ad
 import numpy as np
 import pandas as pd
@@ -30,7 +31,9 @@ def _col(values, encoding):
     if encoding == "text_plus":
         return pd.Series([tokens[v] for v in values])
     if encoding == "text_truefalse":
-        return pd.Series([{True: "True", False: "False", None: None}[v] for v in values])
+        return pd.Series(
+            [{True: "True", False: "False", None: None}[v] for v in values]
+        )
     if encoding == "text_10":
         return pd.Series([{True: "1", False: "0", None: None}[v] for v in values])
     if encoding == "string_dtype":
@@ -40,20 +43,45 @@ def _col(values, encoding):
     if encoding == "nullable_boolean":
         return pd.Series([pd.NA if v is None else v for v in values], dtype="boolean")
     if encoding == "numeric":
-        return pd.Series([np.nan if v is None else nums[v] for v in values], dtype="float64")
+        return pd.Series(
+            [np.nan if v is None else nums[v] for v in values], dtype="float64"
+        )
     if encoding == "categorical_text":
         return pd.Series(pd.Categorical([tokens[v] for v in values]))
     if encoding == "categorical_numeric":
         return pd.Series(pd.Categorical([nums[v] for v in values]))
     if encoding == "categorical_bool":
-        return pd.Series(pd.Categorical([None if v is None else bool(v) for v in values]))
+        return pd.Series(
+            pd.Categorical([None if v is None else bool(v) for v in values])
+        )
+    if encoding == "categorical_numeric_string":
+        # Categorical over the STRINGS "0"/"1" (categories.dtype == object).
+        return pd.Series(
+            pd.Categorical([{True: "1", False: "0", None: None}[v] for v in values])
+        )
+    if encoding == "categorical_bool_string":
+        # Categorical over the STRINGS "True"/"False" (categories.dtype == object).
+        return pd.Series(
+            pd.Categorical(
+                [{True: "True", False: "False", None: None}[v] for v in values]
+            )
+        )
     raise AssertionError(encoding)
 
 
 ENCODINGS = [
-    "text_plus", "text_truefalse", "text_10", "string_dtype", "bool",
-    "nullable_boolean", "numeric", "categorical_text", "categorical_numeric",
+    "text_plus",
+    "text_truefalse",
+    "text_10",
+    "string_dtype",
+    "bool",
+    "nullable_boolean",
+    "numeric",
+    "categorical_text",
+    "categorical_numeric",
     "categorical_bool",
+    "categorical_numeric_string",
+    "categorical_bool_string",
 ]
 
 
@@ -78,8 +106,11 @@ def test_missing_is_not_flagged(encoding, pandas_infer_string):
 @pytest.mark.parametrize("encoding", ["string_dtype", "text_plus"])
 def test_zero_and_false_tokens_are_not_flagged(encoding, pandas_infer_string):
     """The exact corruption case: '0' and 'False' must NOT count as flagged."""
-    col = pd.Series(pd.array(["0", "False", "+"], dtype="string")) \
-        if encoding == "string_dtype" else pd.Series(["0", "False", "+"])
+    col = (
+        pd.Series(pd.array(["0", "False", "+"], dtype="string"))
+        if encoding == "string_dtype"
+        else pd.Series(["0", "False", "+"])
+    )
     mask = boolean_flag_mask(col)
     assert list(mask) == [False, False, True]
 
@@ -92,7 +123,10 @@ def test_categorical_without_empty_string_does_not_raise(pandas_infer_string):
     assert list(mask) == [True, False, True, False]
 
 
-@pytest.mark.parametrize("encoding", ["string_dtype", "text_plus", "categorical_text"])
+@pytest.mark.parametrize(
+    "encoding",
+    ["string_dtype", "text_plus", "categorical_text", "categorical_numeric_string"],
+)
 def test_anndata_features_retained_through_filter(encoding, pandas_infer_string):
     """Integration: apply the exact call-site expression to a real AnnData and
     assert the non-contaminant features survive (not a zeroed matrix)."""

--- a/tests/unit/core/adapters/test_intensity_metadata_dtype.py
+++ b/tests/unit/core/adapters/test_intensity_metadata_dtype.py
@@ -12,6 +12,7 @@ NOT recognized as metadata, stayed in the intensity set, and was silently
 coerced to all-NaN. These tests assert the text column lands in metadata under
 both ``pd.options.future.infer_string`` regimes.
 """
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -80,3 +81,54 @@ def test_numeric_string_column_not_blanked(cls, pandas_infer_string):
     assert "abundance" in intensity_df.columns
     assert list(intensity_df["abundance"]) == [100.0, 200.0]
     assert metadata_df is not None and "label" in metadata_df.columns
+
+
+@pytest.mark.parametrize("cls", [ProteomicsAdapter, MetabolomicsAdapter])
+def test_late_text_value_routes_column_to_metadata(cls, pandas_infer_string):
+    """Position-independence (follow-on to the P0 fix). A real text token AFTER
+    the first ten numeric-looking rows must still route the column to metadata,
+    not intensity. The prior ``head(10)`` sampling classified it as intensity
+    and the downstream coerce blanked the token to NaN."""
+    values = [str(i) for i in range(10)] + ["control"]  # 10 numeric, then text
+    df = pd.DataFrame(
+        {
+            "mostly_numeric": pd.Series(values),  # matches no name pattern
+            "s1": [float(i) for i in range(11)],
+        }
+    )
+    adapter = _adapter(cls)
+    # The predicate itself must be position-independent.
+    assert adapter._is_numeric_string_column(df["mostly_numeric"]) is False
+    intensity_df, metadata_df = adapter._separate_intensity_metadata_columns(df)
+    assert metadata_df is not None and "mostly_numeric" in metadata_df.columns
+    assert "mostly_numeric" not in intensity_df.columns
+    # The text token is preserved, not silently coerced to NaN.
+    assert "control" in list(metadata_df["mostly_numeric"])
+
+
+@pytest.mark.parametrize("cls", [ProteomicsAdapter, MetabolomicsAdapter])
+def test_fully_numeric_string_column_beyond_ten_rows_is_intensity(
+    cls, pandas_infer_string
+):
+    """The full scan must not create false metadata: a column of >10
+    numeric-encoded strings stays intensity and coerces to real numbers."""
+    values = [str(float(i)) for i in range(15)]
+    df = pd.DataFrame({"abundance": pd.Series(values), "label": pd.Series(["x"] * 15)})
+    adapter = _adapter(cls)
+    assert adapter._is_numeric_string_column(df["abundance"]) is True
+    intensity_df, _ = adapter._separate_intensity_metadata_columns(df)
+    assert "abundance" in intensity_df.columns
+    assert not intensity_df["abundance"].isna().all()
+
+
+@pytest.mark.parametrize("cls", [ProteomicsAdapter, MetabolomicsAdapter])
+def test_empty_string_token_routes_column_to_metadata(cls, pandas_infer_string):
+    """'' coerces to NaN WITHOUT raising, so a column containing it is not fully
+    numeric and must route to metadata (token preserved), not intensity where
+    the empty string would be blanked. Codex follow-on finding."""
+    df = pd.DataFrame({"maybe_num": pd.Series(["1", "2", ""]), "s1": [1.0, 2.0, 3.0]})
+    adapter = _adapter(cls)
+    assert adapter._is_numeric_string_column(df["maybe_num"]) is False
+    intensity_df, metadata_df = adapter._separate_intensity_metadata_columns(df)
+    assert metadata_df is not None and "maybe_num" in metadata_df.columns
+    assert "maybe_num" not in intensity_df.columns

--- a/tests/unit/core/backends/test_h5ad_backend_string_dtype.py
+++ b/tests/unit/core/backends/test_h5ad_backend_string_dtype.py
@@ -9,11 +9,14 @@ for no benefit. These tests pin that decision (a future broadening would
 re-introduce the corruption) and confirm the object mixed-type path still
 produces a writable object.
 """
+
 import anndata as ad
 import numpy as np
 import pandas as pd
+import pytest
 
 from lobster.core.backends.h5ad_backend import H5ADBackend
+from lobster.core.utils.h5ad_utils import is_arrow_dtype
 
 
 def _adata(var: pd.DataFrame) -> ad.AnnData:
@@ -26,9 +29,11 @@ def test_string_id_column_is_preserved_not_coerced():
     var = pd.DataFrame({"sample_id": pd.array(["001", "002", "003"], dtype="string")})
     adata = _adata(var)
     H5ADBackend.sanitize_anndata(adata)
-    assert list(adata.var["sample_id"]) == ["001", "002", "003"], (
-        f"leading-zero string IDs were corrupted: {list(adata.var['sample_id'])}"
-    )
+    assert list(adata.var["sample_id"]) == [
+        "001",
+        "002",
+        "003",
+    ], f"leading-zero string IDs were corrupted: {list(adata.var['sample_id'])}"
 
 
 def test_sanitized_mixed_object_column_is_writable(tmp_path):
@@ -42,3 +47,97 @@ def test_sanitized_mixed_object_column_is_writable(tmp_path):
     back = ad.read_h5ad(out)
     assert back.n_vars == 3
     assert list(back.var["mixed"]) == ["ok", "1", "NA"]
+
+
+def test_object_leading_zero_ids_are_preserved(tmp_path):
+    # OBJECT-dtype (not StringDtype) numeric-looking IDs with leading zeros hit
+    # the sanitizer's object branch, where the old code ran unconditional
+    # pd.to_numeric and rewrote "001" -> 1. The conservative coercion must leave
+    # them untouched. This is the pre-existing corruption tracked as a follow-on.
+    var = pd.DataFrame({"sample_id": pd.Series(["001", "002", "003"], dtype=object)})
+    adata = _adata(var)
+    H5ADBackend.sanitize_anndata(adata)
+    assert list(adata.var["sample_id"]) == [
+        "001",
+        "002",
+        "003",
+    ], f"object leading-zero IDs were coerced: {list(adata.var['sample_id'])}"
+    out = tmp_path / "ids.h5ad"
+    adata.write_h5ad(out)  # must remain writable
+    assert list(ad.read_h5ad(out).var["sample_id"]) == ["001", "002", "003"]
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        ["001", "002"],  # leading zeros
+        [" 1 ", "2 "],  # surrounding whitespace (identity includes spaces)
+        ["1", ""],  # empty-string token (parses to NaN, must not coerce)
+        ["1.50", "2.50"],  # non-canonical decimal spelling
+        ["1e3", "2e3"],  # exponent form
+        ["+1", "+2"],  # explicit sign
+    ],
+)
+def test_object_non_roundtrip_strings_are_preserved(values):
+    # Numeric-looking object strings whose text does not survive coercion must
+    # be kept verbatim (identifier safety). Regression guard for the Codex
+    # findings: whitespace/empty-string false-accept and exponent/sign forms.
+    var = pd.DataFrame({"col": pd.Series(values, dtype=object)})
+    adata = _adata(var)
+    H5ADBackend.sanitize_anndata(adata)
+    assert list(adata.var["col"]) == values
+
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        (["1", "2", "3"], [1, 2, 3]),
+        (["1.0", "2.0"], [1.0, 2.0]),  # canonical float spelling must coerce
+        (["0.0", "5.0"], [0.0, 5.0]),
+        (["9223372036854775807", "1"], [9223372036854775807, 1]),  # exact int64
+    ],
+)
+def test_object_canonical_numeric_strings_coerce(values, expected):
+    # Canonical numeric spellings still coerce — no false-reject from the guard.
+    var = pd.DataFrame({"col": pd.Series(values, dtype=object)})
+    adata = _adata(var)
+    H5ADBackend.sanitize_anndata(adata)
+    assert list(adata.var["col"]) == expected
+
+
+def test_object_string_infinity_does_not_crash(tmp_path):
+    # Regression: the lossless helper must not call int() on float infinity
+    # (OverflowError). "inf"/"-inf" coerce to numeric infinities as before.
+    var = pd.DataFrame({"col": pd.Series(["inf", "-inf"], dtype=object)})
+    adata = _adata(var)
+    H5ADBackend.sanitize_anndata(adata)  # must not raise
+    out = tmp_path / "inf.h5ad"
+    adata.write_h5ad(out)  # must remain writable
+
+
+def test_is_arrow_dtype_recognizes_string_extension_dtypes():
+    # StringDtype (and, under pandas 3, the default `str` dtype) must be
+    # recognized so convert_arrow_to_standard materializes it to object before
+    # write. Plain object / numeric must NOT be treated as extension dtypes.
+    assert is_arrow_dtype(pd.Series(pd.array(["a", "b"], dtype="string"))) is True
+    assert is_arrow_dtype(pd.Index(pd.array(["g0", "g1"], dtype="string"))) is True
+    assert is_arrow_dtype(pd.Series(["a", "b"], dtype=object)) is False
+    assert is_arrow_dtype(pd.Series([1, 2, 3])) is False
+
+
+def test_save_roundtrips_string_dtype_column_and_index(tmp_path):
+    # Full H5ADBackend.save() path (P0). A StringDtype var column + index must
+    # write and read back with values preserved. If is_arrow_dtype fails to
+    # recognize the extension dtype, save() forces infer_string=False and anndata
+    # refuses to write the nullable-string arrays.
+    var = pd.DataFrame(
+        {"sample_id": pd.array(["001", "002", "003"], dtype="string")},
+        index=pd.Index(pd.array(["g0", "g1", "g2"], dtype="string"), name="gene_id"),
+    )
+    adata = ad.AnnData(X=np.ones((2, 3), dtype=float), var=var)
+    backend = H5ADBackend(base_path=str(tmp_path))
+    out = tmp_path / "string_dtype.h5ad"
+    backend.save(adata, str(out))  # must not raise
+    back = ad.read_h5ad(out)
+    assert list(back.var["sample_id"]) == ["001", "002", "003"]
+    assert list(back.var_names) == ["g0", "g1", "g2"]

--- a/tests/unit/core/utils/test_dtype_guards.py
+++ b/tests/unit/core/utils/test_dtype_guards.py
@@ -4,6 +4,7 @@ Covers the two predicates that replace ``dtype == "object"`` across the engine,
 including the object-with-NaN and object-numeric edge cases that a naive
 ``is_string_dtype``-only swap gets wrong.
 """
+
 import warnings
 
 import numpy as np
@@ -17,8 +18,8 @@ from lobster.core.utils.dtype_guards import boolean_flag_mask, is_text_dtype
     "data,expected",
     [
         (pd.Series(["a", "b"], dtype=object), True),
-        (pd.Series(["a", np.nan, "b"], dtype=object), True),   # object-with-NaN
-        (pd.Series([1, 2, None], dtype=object), True),         # non-string object
+        (pd.Series(["a", np.nan, "b"], dtype=object), True),  # object-with-NaN
+        (pd.Series([1, 2, None], dtype=object), True),  # non-string object
         (pd.Series(pd.array(["a", "b"], dtype="string")), True),
         (pd.Series([1.0, 2.0]), False),
         (pd.Series([True, False]), False),
@@ -39,8 +40,16 @@ def _keep(col):
 
 def test_flag_mask_object_numeric_values():
     # object dtype holding python numbers: nonzero flagged, 0/NaN not.
-    assert list(boolean_flag_mask(pd.Series([2, 0, None], dtype=object))) == [True, False, False]
-    assert list(boolean_flag_mask(pd.Series([1.0, 0.0, np.nan], dtype=object))) == [True, False, False]
+    assert list(boolean_flag_mask(pd.Series([2, 0, None], dtype=object))) == [
+        True,
+        False,
+        False,
+    ]
+    assert list(boolean_flag_mask(pd.Series([1.0, 0.0, np.nan], dtype=object))) == [
+        True,
+        False,
+        False,
+    ]
 
 
 def test_flag_mask_object_string_with_nan():
@@ -49,7 +58,10 @@ def test_flag_mask_object_string_with_nan():
 
 
 def test_flag_mask_all_missing_and_empty():
-    assert list(boolean_flag_mask(pd.Series([None, None], dtype=object))) == [False, False]
+    assert list(boolean_flag_mask(pd.Series([None, None], dtype=object))) == [
+        False,
+        False,
+    ]
     assert list(boolean_flag_mask(pd.Series([], dtype=object))) == []
 
 
@@ -59,7 +71,10 @@ def test_flag_mask_all_missing_and_empty():
         (pd.Series(["+", "", "+", ""]), [True, False, True, False]),
         (pd.Series(["1", "0", "1", "0"]), [True, False, True, False]),
         (pd.Series(["True", "False", "True", "False"]), [True, False, True, False]),
-        (pd.Series(["YES", "no", "y", "Nope"]), [True, False, False, False]),  # 'y' not a token
+        (
+            pd.Series(["YES", "no", "y", "Nope"]),
+            [True, False, False, False],
+        ),  # 'y' not a token
         (pd.Series([True, False, True, False]), [True, False, True, False]),
         (pd.Series([True, pd.NA, False], dtype="boolean"), [True, False, False]),
         (pd.Series([1, 0, 2, 0]), [True, False, True, False]),
@@ -68,6 +83,16 @@ def test_flag_mask_all_missing_and_empty():
         (pd.Series(pd.Categorical(["+", "", "+"])), [True, False, True]),
         (pd.Series(pd.Categorical([1, 0, 1])), [True, False, True]),
         (pd.Series(pd.Categorical([True, False])), [True, False]),
+        # Categorical whose CATEGORIES are numeric-/bool-strings (['0','1'],
+        # ['True','False']): categories.dtype is object -> _from_text route.
+        # These are the encodings that TypeError under the old
+        # fillna("")-on-categorical path; this closes the accepted-cut coverage
+        # gap (correctness was proven by execution; this guards regression).
+        (pd.Series(pd.Categorical(["1", "0", "1", "0"])), [True, False, True, False]),
+        (
+            pd.Series(pd.Categorical(["True", "False", "True", "False"])),
+            [True, False, True, False],
+        ),
     ],
 )
 def test_flag_mask_matrix_no_downcast_warning(col, expected):


### PR DESCRIPTION
Stacked on `fix/pandas3-dtype-corruption` so it reviews as a single commit.

`04d833ba` fixed the dtype corruption at the point it was found. This hardens the
places the same class of bug can recur: the metabolomics and proteomics adapters,
the h5ad backend, and the shared dtype guards.

## The point worth reviewing

The four test files this adds **had never been executed**. They existed in the
commit and were treated as evidence; they were not evidence yet. They have now
been run, with the project's own `addopts` intact — `--strict-markers` and
`--strict-config` active, `configfile: pyproject.toml`, no `-o addopts` override
(overriding it silently drops strict markers):

    packages/lobster-proteomics/tests/agents/test_contaminant_reverse_dtype.py
    tests/unit/core/adapters/test_intensity_metadata_dtype.py
    tests/unit/core/backends/test_h5ad_backend_string_dtype.py
    tests/unit/core/utils/test_dtype_guards.py

**126 passed, 2 skipped.** Both skips are in the contaminant/reverse parametrised
set and carry the reason `numpy bool cannot represent missing` — a case that
genuinely cannot apply, not a suppressed failure.

Several of the tests are parametrised over `infer_string` on and off, which is the
property that actually broke rather than the pandas version string.

Review only. Merge after the base PR.
