### PR TITLE
ci: remove the unpinned cross-repo production deploy dispatch

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -685,30 +685,30 @@ jobs:
           fi
 
   # ===========================================================================
-  # Step 6: Trigger Omics-OS Cloud Deployment
+  # Step 6: (removed) Trigger Omics-OS Cloud Deployment
   # ===========================================================================
-  trigger-cloud-deploy:
-    name: Trigger Cloud Deploy
-    needs:
-      - validate-version
-      - publish-lobster-ai
-    # Only fire when core package published successfully
-    if: needs.publish-lobster-ai.result == 'success'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Wait for PyPI index propagation
-        run: sleep 60
-
-      - name: Dispatch to lobster-cloud
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.LOBSTER_CLOUD_DEPLOY_TOKEN }}
-          repository: the-omics-os/lobster-cloud
-          event-type: lobster-packages-published
-          client-payload: >-
-            {
-              "version": "${{ needs.validate-version.outputs.version }}",
-              "is_test": "${{ needs.validate-version.outputs.is_test }}",
-              "source_run": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+  #
+  # A `trigger-cloud-deploy` job used to live here. On every `v*.*.*` tag it
+  # sent a `repository_dispatch` of type `lobster-packages-published` to
+  # the-omics-os/lobster-cloud, which ran a production ECS deploy with no engine
+  # pin — so publishing this package redeployed the Cloud backend from whatever
+  # this repository's `main` happened to be at that minute, with no human in the
+  # loop. That is the mechanism behind the 2026-08-17 pandas-3 production outage.
+  # It was not merely theoretical: the consumer succeeded 17 times, most recently
+  # 2026-03-26 and 2026-03-27, both after the Cloud Dockerfile had switched to an
+  # unpinned `@main` install. The payload's `is_test` was read and never used to
+  # skip, so a `-test` tag deployed production too.
+  #
+  # The consumer trigger was removed in lobster-cloud (be81078b, 2026-08-17), so
+  # the event now lands with nothing listening. This job is removed as well
+  # because an inert dispatch is a loaded one: the next person to add any
+  # `repository_dispatch` listener over there re-arms it without knowing it
+  # exists.
+  #
+  # Cloud deploys are a deliberate act from a workstation: `cli deploy core-api`,
+  # which injects the tracked engine pin (lobster-cloud engine-pin.txt) and fails
+  # closed if it is missing. Do not restore automatic cross-repo deployment.
+  #
+  # `secrets.LOBSTER_CLOUD_DEPLOY_TOKEN` is now unused by this workflow. It is a
+  # cross-repo credential carrying production-deploy intent; it is flagged for a
+  # decision rather than rotated here.


### PR DESCRIPTION
Removes the `Trigger Cloud Deploy` job from `publish-packages.yml`.

## What it did

On every `v*.*.*` tag, that job sent a `repository_dispatch` event
(`lobster-packages-published`) to `the-omics-os/lobster-cloud`, where
`deploy-backend.yml` listened for it and ran
`cdk deploy LobsterCloudStack --require-approval never` — **with no engine pin**.
So an engine release could redeploy production from whatever `main` happened to
be, with no human in the loop. For the six weeks that `main` was `d1983964`, that
would have shipped the pandas-3 dtype corruption and the silent loss of GWAS
tools.

## Why it is safe to remove rather than repair

It has not been able to fire for months, for two independent reasons, and neither
is a control anyone chose:

- `secrets.LOBSTER_CLOUD_DEPLOY_TOKEN` is a PAT last set 2026-02-15 and long
  expired — every dispatch since at least v1.1.418 (2026-05-02) failed with
  `Bad credentials`.
- The **consumer is already gone**. `lobster-cloud`'s `deploy-backend.yml` no
  longer declares a `repository_dispatch` trigger on its default branch; it is
  `workflow_dispatch`-only, and the static AWS credentials it used were deleted
  on 2026-08-20. Even a perfectly authenticated dispatch now lands on a repo with
  nothing listening and no credentials to deploy with.

Deploys go through the internal ops CLI wrapper, which injects the tracked engine
pin and refuses to synth without a full 40-character SHA. That is the path that
should stay, and it is unaffected by this change.

## Relationship to PR #20

PR #20 replaces the expired PAT with a per-run GitHub App token — i.e. it
**repairs** this job. Being closed in favour of this PR: with the consumer
removed, a working token buys nothing, and it would re-establish a mechanism that
becomes dangerous again the moment anyone re-adds a `repository_dispatch` handler.
The App-token pattern in #20 is sound and worth keeping in mind for a *pinned,
reviewed* release pipeline later; it is the unpinned auto-deploy that is being
retired here, not the token approach.
