### PR TITLE
Feature/ncbi geo count availability

### DIFF
--- a/lobster/agents/graph.py
+++ b/lobster/agents/graph.py
@@ -175,32 +175,6 @@ async def _invoke_and_store(
         return f"Agent {agent_name} returned no response."
 
     content = final_msg.content if hasattr(final_msg, "content") else str(final_msg)
-    if agent_name == "research_agent":
-        # The model's final summary may omit availability from preparation tools.
-        # Preserve it explicitly at the supervisor handoff, without queue storage.
-        preparation_calls = {
-            call["id"]: call["args"].get("accession")
-            or call["args"].get("identifier")
-            for message in result.get("messages", [])
-            for call in getattr(message, "tool_calls", [])
-            if call["name"]
-            in {"prepare_dataset_download", "validate_dataset_metadata"}
-        }
-        availability = []
-        for message in result.get("messages", []):
-            accession = preparation_calls.get(getattr(message, "tool_call_id", None))
-            if accession and (
-                "has_ncbi_rnaseq_counts=True: "
-                "An NCBI-generated raw count source is also available."
-            ) in str(getattr(message, "content", "")):
-                notice = (
-                    f"{accession}: has_ncbi_rnaseq_counts=True: "
-                    "An NCBI-generated raw count source is also available."
-                )
-                if notice not in availability and notice not in content:
-                    availability.append(notice)
-        if availability:
-            content = f"{content}\n\n" + "\n".join(availability)
     logger.debug(f"Agent {agent_name} completed. Response length: {len(content)}")
 
     # Dual-write: store full result for later retrieval

--- a/lobster/agents/graph.py
+++ b/lobster/agents/graph.py
@@ -175,6 +175,32 @@ async def _invoke_and_store(
         return f"Agent {agent_name} returned no response."
 
     content = final_msg.content if hasattr(final_msg, "content") else str(final_msg)
+    if agent_name == "research_agent":
+        # The model's final summary may omit availability from preparation tools.
+        # Preserve it explicitly at the supervisor handoff, without queue storage.
+        preparation_calls = {
+            call["id"]: call["args"].get("accession")
+            or call["args"].get("identifier")
+            for message in result.get("messages", [])
+            for call in getattr(message, "tool_calls", [])
+            if call["name"]
+            in {"prepare_dataset_download", "validate_dataset_metadata"}
+        }
+        availability = []
+        for message in result.get("messages", []):
+            accession = preparation_calls.get(getattr(message, "tool_call_id", None))
+            if accession and (
+                "has_ncbi_rnaseq_counts=True: "
+                "An NCBI-generated raw count source is also available."
+            ) in str(getattr(message, "content", "")):
+                notice = (
+                    f"{accession}: has_ncbi_rnaseq_counts=True: "
+                    "An NCBI-generated raw count source is also available."
+                )
+                if notice not in availability and notice not in content:
+                    availability.append(notice)
+        if availability:
+            content = f"{content}\n\n" + "\n".join(availability)
     logger.debug(f"Agent {agent_name} completed. Response length: {len(content)}")
 
     # Dual-write: store full result for later retrieval

--- a/lobster/agents/graph.py
+++ b/lobster/agents/graph.py
@@ -141,7 +141,7 @@ def _get_parent_agent(agent_name: str, worker_agents: Dict) -> Optional[str]:
 
 
 async def _invoke_and_store(
-    agent, agent_name: str, task_description: str, store
+    agent, agent_name: str, task_description: str, store, data_manager=None
 ) -> str:
     """Shared invoke pipeline for all delegation tools.
 
@@ -165,31 +165,105 @@ async def _invoke_and_store(
         "metadata": {"agent_name": agent_name},
     }
 
-    result = await agent.ainvoke(
-        {"messages": [{"role": "user", "content": task_description}]}, config=config
-    )
+    from langgraph.errors import GraphInterrupt
 
-    # Extract the final message content
-    final_msg = result.get("messages", [])[-1] if result.get("messages") else None
-    if final_msg is None:
-        return f"Agent {agent_name} returned no response."
+    stage = "invoke_agent"
+    logger.info("[GEO preference] handoff start agent=%s", agent_name)
+    try:
+        result = await agent.ainvoke(
+            {"messages": [{"role": "user", "content": task_description}]}, config=config
+        )
 
-    content = final_msg.content if hasattr(final_msg, "content") else str(final_msg)
-    logger.debug(f"Agent {agent_name} completed. Response length: {len(content)}")
+        logger.info(
+            "[GEO preference] handoff invocation returned agent=%s result_type=%s",
+            agent_name,
+            type(result).__name__,
+        )
+        stage = "extract_final_message"
+        # Extract the final message content
+        final_msg = result.get("messages", [])[-1] if result.get("messages") else None
+        if final_msg is None:
+            logger.warning(
+                "[GEO preference] handoff has no final message agent=%s", agent_name
+            )
+            return f"Agent {agent_name} returned no response."
 
-    # Dual-write: store full result for later retrieval
-    if store is not None:
-        from lobster.tools.store_tools import store_delegation_result
+        content = final_msg.content if hasattr(final_msg, "content") else str(final_msg)
+        if agent_name == "research_agent" and data_manager is not None:
+            stage = "append_geo_availability"
+            logger.info(
+                "[GEO preference] availability summary start agent=%s", agent_name
+            )
+            accessions = {
+                str(
+                    call.get("args", {}).get("accession")
+                    or call.get("args", {}).get("identifier")
+                    or ""
+                ).upper()
+                for message in result.get("messages", [])
+                for call in getattr(message, "tool_calls", [])
+                if call.get("name")
+                in {"prepare_dataset_download", "validate_dataset_metadata"}
+            }
+            logger.info(
+                "[GEO preference] preparation accessions=%s", sorted(accessions)
+            )
+            notices = []
+            for entry in data_manager.download_queue.list_entries():
+                original = str(entry.metadata.get("original_accession", "")).upper()
+                if entry.database.lower() == "geo" and (
+                    entry.dataset_id.upper() in accessions
+                    or (original and original in accessions)
+                ):
+                    available = entry.has_ncbi_rnaseq_counts
+                    notices.append(
+                        f"{entry.dataset_id} (entry_id={entry.entry_id}): "
+                        f"has_ncbi_rnaseq_counts={available}; "
+                        f"selected_source={entry.selected_source}; "
+                        f"source_preference_answered={entry.source_preference_answered}. "
+                        "Preference is informational; download execution is unchanged."
+                    )
+            logger.info(
+                "[GEO preference] availability summary completed notices=%s",
+                len(notices),
+            )
+            if notices:
+                content = (
+                    str(content) + "\n\nGEO source availability:\n" + "\n".join(notices)
+                )
 
-        store_key = store_delegation_result(store, agent_name, content)
-        if store_key:
-            content = f"{content}\n\n[store_key={store_key}]"
+        logger.debug(f"Agent {agent_name} completed. Response length: {len(content)}")
 
-    return content
+        stage = "store_handoff_result"
+        # Dual-write: store full result for later retrieval
+        if store is not None:
+            from lobster.tools.store_tools import store_delegation_result
+
+            store_key = store_delegation_result(store, agent_name, content)
+            if store_key:
+                content = f"{content}\n\n[store_key={store_key}]"
+
+        logger.info("[GEO preference] handoff complete agent=%s", agent_name)
+        return content
+    except GraphInterrupt:
+        logger.info(
+            "[GEO preference] handoff paused agent=%s stage=%s", agent_name, stage
+        )
+        raise
+    except Exception:
+        logger.exception(
+            "[GEO preference] handoff failed agent=%s stage=%s", agent_name, stage
+        )
+        raise
 
 
 def _create_agent_tool(
-    agent_name: str, agent, tool_name: str, description: str, store=None
+    agent_name: str,
+    agent,
+    tool_name: str,
+    description: str,
+    store=None,
+    data_manager=None,
 ):
     """Create a tool that invokes a sub-agent (Tool Calling pattern).
 
@@ -216,7 +290,9 @@ def _create_agent_tool(
         logger.info(
             f"=== HANDOFF TO {agent_name} ===\n{task_description[:500]}\n=== END HANDOFF ==="
         )
-        return await _invoke_and_store(agent, agent_name, task_description, _store)
+        return await _invoke_and_store(
+            agent, agent_name, task_description, _store, data_manager
+        )
 
     invoke_agent.metadata = {"categories": ["DELEGATE"], "provenance": False}
     invoke_agent.tags = ["DELEGATE"]
@@ -584,6 +660,7 @@ def _build_supervisor_tools(
                 tool_name=agent_config.handoff_tool_name,
                 description=desc,
                 store=store,
+                data_manager=data_manager,
             )
             agent_tools.append(agent_tool)
             supervisor_accessible_names.append(agent_config.name)
@@ -786,6 +863,7 @@ def create_bioinformatics_graph(
         config = {"recursion_limit": 1000, ...}
         graph.invoke(input, config)
     """
+    data_manager._interactive = interactive
     _log_dependency_versions()
 
     # Auto-detect subscription tier if not provided

--- a/lobster/agents/supervisor.py
+++ b/lobster/agents/supervisor.py
@@ -382,6 +382,20 @@ def _build_response_behavior(config: SupervisorConfig, interactive: bool = True)
                 "- Fetch metadata preview first and confirm before downloading datasets."
             )
 
+        if (
+            config.require_download_confirmation or config.require_metadata_preview
+        ) and not config.admin_mode:
+            rules.append(
+                "- At the existing pre-download confirmation, when research reports "
+                "has_ncbi_rnaseq_counts=True for the dataset, tell the user: "
+                "'An NCBI-generated raw count source is also available. "
+                "Do you prefer the author-provided GEO source or the NCBI-generated "
+                "raw counts?' Explain that the preference is informational for now. "
+                "Do not persist or act on the answer, or change the queue, selected "
+                "strategy, URLs, files, or download execution. If the flag is false "
+                "or absent, keep the existing confirmation behavior unchanged."
+            )
+
     if config.summarize_expert_output:
         rules.append(
             "- Summarize expert output with key findings, metrics, and file names (2-4 sentences)."

--- a/lobster/agents/supervisor.py
+++ b/lobster/agents/supervisor.py
@@ -382,20 +382,6 @@ def _build_response_behavior(config: SupervisorConfig, interactive: bool = True)
                 "- Fetch metadata preview first and confirm before downloading datasets."
             )
 
-        if (
-            config.require_download_confirmation or config.require_metadata_preview
-        ) and not config.admin_mode:
-            rules.append(
-                "- At the existing pre-download confirmation, when research reports "
-                "has_ncbi_rnaseq_counts=True for the dataset, tell the user: "
-                "'An NCBI-generated raw count source is also available. "
-                "Do you prefer the author-provided GEO source or the NCBI-generated "
-                "raw counts?' Explain that the preference is informational for now. "
-                "Do not persist or act on the answer, or change the queue, selected "
-                "strategy, URLs, files, or download execution. If the flag is false "
-                "or absent, keep the existing confirmation behavior unchanged."
-            )
-
     if config.summarize_expert_output:
         rules.append(
             "- Summarize expert output with key findings, metrics, and file names (2-4 sentences)."

--- a/lobster/core/client.py
+++ b/lobster/core/client.py
@@ -595,6 +595,13 @@ class AgentClient(BaseClient):
                     if isinstance(chunk, dict):
                         # HITL interrupt detection (Phase 2).
                         if "__interrupt__" in chunk:
+                            logger.info(
+                                "[GEO preference] chat stream received interrupt session=%s interactive=%s namespace=%s count=%s",
+                                self.session_id,
+                                self.interactive,
+                                namespace,
+                                len(chunk["__interrupt__"]),
+                            )
                             if not self.interactive:
                                 logger.warning(
                                     "HITL interrupt fired in non-interactive streaming mode"
@@ -735,6 +742,12 @@ class AgentClient(BaseClient):
             "callbacks": self.callbacks,
             "recursion_limit": 1000,
         }
+        logger.info(
+            "[GEO preference] chat resume requested session=%s response_type=%s stream=%s",
+            self.session_id,
+            type(response).__name__,
+            stream,
+        )
         stream_input = Command(resume=response)
         if stream:
             yield from self._stream_query(

--- a/lobster/core/interfaces/queue_preparer.py
+++ b/lobster/core/interfaces/queue_preparer.py
@@ -56,12 +56,14 @@ class QueuePreparationResult:
         url_data: DownloadUrlResult from the provider (for inspection/logging)
         metadata: Raw metadata dict from the database
         validation_summary: Human-readable summary of preparation
+        has_ncbi_rnaseq_counts: Informational availability flag, not persisted in queue
     """
 
     queue_entry: "DownloadQueueEntry"
     url_data: Optional["DownloadUrlResult"] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
     validation_summary: str = ""
+    has_ncbi_rnaseq_counts: bool = False
 
 
 class IQueuePreparer(ABC):

--- a/lobster/core/interfaces/queue_preparer.py
+++ b/lobster/core/interfaces/queue_preparer.py
@@ -30,10 +30,13 @@ Usage Example:
 from __future__ import annotations
 
 import uuid
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from lobster.core.data_manager_v2 import DataManagerV2
@@ -56,14 +59,12 @@ class QueuePreparationResult:
         url_data: DownloadUrlResult from the provider (for inspection/logging)
         metadata: Raw metadata dict from the database
         validation_summary: Human-readable summary of preparation
-        has_ncbi_rnaseq_counts: Informational availability flag, not persisted in queue
     """
 
     queue_entry: "DownloadQueueEntry"
     url_data: Optional["DownloadUrlResult"] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
     validation_summary: str = ""
-    has_ncbi_rnaseq_counts: bool = False
 
 
 class IQueuePreparer(ABC):
@@ -157,6 +158,10 @@ class IQueuePreparer(ABC):
         """
         ...
 
+    def prepare_source(self, accession: str) -> Dict[str, Any]:
+        """Optional source metadata collected before constructing an entry."""
+        return {}
+
     def prepare_queue_entry(
         self, accession: str, priority: int = 5
     ) -> QueuePreparationResult:
@@ -181,11 +186,31 @@ class IQueuePreparer(ABC):
         # Step 1: Fetch metadata
         metadata, validation_info = self.fetch_metadata(accession)
 
+        logger.info(
+            "[GEO preference] metadata fetched; preparing source accession=%s preparer=%s",
+            accession,
+            type(self).__name__,
+        )
+        source_fields = self.prepare_source(accession)
+        logger.info(
+            "[GEO preference] source prepared; extracting URLs accession=%s", accession
+        )
+
         # Step 2: Extract download URLs
         url_data = self.extract_download_urls(accession)
 
+        logger.info(
+            "[GEO preference] URLs extracted; recommending strategy accession=%s",
+            accession,
+        )
+
         # Step 3: Recommend strategy
         recommended_strategy = self.recommend_strategy(metadata, url_data, accession)
+
+        logger.info(
+            "[GEO preference] strategy ready; constructing queue entry accession=%s",
+            accession,
+        )
 
         # Step 4: Assemble queue entry
         database = self.supported_databases()[0]
@@ -195,6 +220,7 @@ class IQueuePreparer(ABC):
         queue_fields = url_data.to_queue_entry_fields()
 
         queue_entry = DownloadQueueEntry(
+            **source_fields,
             entry_id=entry_id,
             dataset_id=accession,
             database=database,
@@ -209,6 +235,12 @@ class IQueuePreparer(ABC):
             h5_url=queue_fields.get("h5_url"),
             created_at=datetime.now(),
             updated_at=datetime.now(),
+        )
+
+        logger.info(
+            "[GEO preference] queue entry constructed accession=%s entry_id=%s",
+            accession,
+            entry_id,
         )
 
         # Build summary

--- a/lobster/core/queues/download_queue.py
+++ b/lobster/core/queues/download_queue.py
@@ -141,6 +141,40 @@ class DownloadQueue:
 
             raise EntryNotFoundError(f"Entry '{entry_id}' not found in queue")
 
+    def update_geo_preference(
+        self, entry_id: str, availability: Optional[bool], source: str, answered: bool
+    ) -> DownloadQueueEntry:
+        """Atomically persist GEO preference without changing execution fields."""
+        logger.info(
+            "[GEO preference] queue preference update start entry_id=%s", entry_id
+        )
+        with self._locked():
+            entries = self._load_entries()
+            for entry in entries:
+                if entry.entry_id == entry_id:
+                    if entry.database.lower() != "geo":
+                        raise ValueError("Source preference applies only to GEO")
+                    updated = DownloadQueueEntry.model_validate(
+                        {
+                            **entry.model_dump(),
+                            "has_ncbi_rnaseq_counts": availability,
+                            "selected_source": source,
+                            "source_preference_answered": answered,
+                            "updated_at": datetime.now(),
+                        }
+                    )
+                    entries[entries.index(entry)] = updated
+                    self._backup_queue()
+                    self._write_entries_atomic(entries)
+                    logger.info(
+                        "[GEO preference] queue preference update persisted entry_id=%s source=%s answered=%s",
+                        entry_id,
+                        source,
+                        answered,
+                    )
+                    return updated
+            raise EntryNotFoundError(entry_id)
+
     def update_status(
         self,
         entry_id: str,

--- a/lobster/core/schemas/download_queue.py
+++ b/lobster/core/schemas/download_queue.py
@@ -8,7 +8,7 @@ by the research_agent and executed by the data_expert.
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -261,6 +261,11 @@ class DownloadQueueEntry(BaseModel):
     recommended_strategy: Optional[StrategyConfig] = Field(
         None, description="Strategy configuration recommended by research_agent"
     )
+
+    # GEO-only informational preference; execution does not consume these fields.
+    has_ncbi_rnaseq_counts: Optional[bool] = None
+    selected_source: Optional[Literal["author", "ncbi"]] = None
+    source_preference_answered: bool = False
 
     # Execution metadata
     created_at: datetime = Field(

--- a/lobster/services/data_access/geo_queue_preparer.py
+++ b/lobster/services/data_access/geo_queue_preparer.py
@@ -300,6 +300,17 @@ class GEOQueuePreparer(IQueuePreparer):
             else:
                 result.queue_entry.metadata = {"original_accession": original_accession}
 
+        # Check only after normal preparation; availability must not affect downloads.
+        if canonical.upper().startswith("GSE"):
+            try:
+                result.has_ncbi_rnaseq_counts = (
+                    self._get_geo_provider().has_ncbi_rnaseq_counts(canonical)
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Could not check NCBI RNA-seq counts for {canonical}: {e}"
+                )
+
         return result
 
     def _resolve_gds_to_gse(self, gds_id: str) -> Optional[str]:

--- a/lobster/services/data_access/geo_queue_preparer.py
+++ b/lobster/services/data_access/geo_queue_preparer.py
@@ -300,18 +300,54 @@ class GEOQueuePreparer(IQueuePreparer):
             else:
                 result.queue_entry.metadata = {"original_accession": original_accession}
 
-        # Check only after normal preparation; availability must not affect downloads.
-        if canonical.upper().startswith("GSE"):
-            try:
-                result.has_ncbi_rnaseq_counts = (
-                    self._get_geo_provider().has_ncbi_rnaseq_counts(canonical)
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Could not check NCBI RNA-seq counts for {canonical}: {e}"
-                )
-
         return result
+
+    # Installed by the research tool layer; non-agent callers do not prompt.
+    source_selector = None
+
+    def prepare_source(self, accession: str) -> Dict[str, Any]:
+        logger.info("[GEO preference] availability check start accession=%s", accession)
+        fields = {
+            "has_ncbi_rnaseq_counts": None,
+            "selected_source": "author",
+            "source_preference_answered": False,
+        }
+        if accession.upper().startswith("GSE"):
+            try:
+                fields["has_ncbi_rnaseq_counts"] = (
+                    self._get_geo_provider().has_ncbi_rnaseq_counts(accession)
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Could not check NCBI RNA-seq counts for %s: %s", accession, exc
+                )
+        logger.info(
+            "[GEO preference] availability check complete accession=%s available=%s selector_installed=%s",
+            accession,
+            fields["has_ncbi_rnaseq_counts"],
+            self.source_selector is not None,
+        )
+        # Deliberately outside the exception handler: interrupts must propagate.
+        if fields["has_ncbi_rnaseq_counts"] is True and self.source_selector:
+            logger.info(
+                "[GEO preference] calling source selector accession=%s", accession
+            )
+            preference = self.source_selector(accession)
+            logger.info(
+                "[GEO preference] source selector returned accession=%s preference=%s",
+                accession,
+                preference,
+            )
+            if preference is not None:
+                fields["selected_source"] = preference
+                fields["source_preference_answered"] = True
+        logger.info(
+            "[GEO preference] source preparation complete accession=%s source=%s answered=%s",
+            accession,
+            fields["selected_source"],
+            fields["source_preference_answered"],
+        )
+        return fields
 
     def _resolve_gds_to_gse(self, gds_id: str) -> Optional[str]:
         """Resolve a GDS accession to its canonical GSE via NCBI Entrez.

--- a/lobster/tools/geo_source_preference.py
+++ b/lobster/tools/geo_source_preference.py
@@ -1,0 +1,63 @@
+"""Informational GEO source preference shared by research preparation tools."""
+
+from langgraph.errors import GraphInterrupt
+from langgraph.types import interrupt
+
+from lobster.services.interaction.component_mapper import map_question
+from lobster.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def ask_geo_source_preference(accession: str) -> str:
+    """Pause before queue creation. The answer does not change download execution."""
+    logger.info("[GEO preference] question mapping start accession=%s", accession)
+    options = ["Author-uploaded GEO data", "NCBI-generated counts"]
+    selection = map_question(
+        f"NCBI-generated counts are available for {accession}. Which source do you "
+        "prefer? This preference is recorded only; the existing download method "
+        "will still be used in this version.",
+        {"options": options},
+    )
+    logger.info(
+        "[GEO preference] interrupt requested accession=%s component=%s",
+        accession,
+        selection.component,
+    )
+    try:
+        response = interrupt(selection.model_dump())
+    except GraphInterrupt:
+        logger.info(
+            "[GEO preference] interrupt raised; awaiting user accession=%s", accession
+        )
+        raise
+    except Exception:
+        logger.exception("[GEO preference] interrupt failed accession=%s", accession)
+        raise
+    logger.info(
+        "[GEO preference] interrupt resumed accession=%s response_type=%s",
+        accession,
+        type(response).__name__,
+    )
+    value = response.get("selected") if isinstance(response, dict) else response
+    choices = {
+        options[0]: "author",
+        options[1]: "ncbi",
+        "author": "author",
+        "ncbi": "ncbi",
+    }
+    if value not in choices:
+        logger.error(
+            "[GEO preference] invalid answer accession=%s value_type=%s",
+            accession,
+            type(value).__name__,
+        )
+        raise ValueError(
+            "No valid GEO source preference was supplied; entry was not created"
+        )
+    logger.info(
+        "[GEO preference] answer accepted accession=%s selected_source=%s",
+        accession,
+        choices[value],
+    )
+    return choices[value]

--- a/lobster/tools/providers/geo_provider.py
+++ b/lobster/tools/providers/geo_provider.py
@@ -249,6 +249,21 @@ class GEOProvider(BasePublicationProvider):
         resolver = get_accession_resolver()
         return resolver.is_geo_identifier(identifier)
 
+    def has_ncbi_rnaseq_counts(self, geo_id: str) -> bool:
+        """Check a GSE for NCBI-generated RNA-seq counts using ESearch."""
+        if not geo_id or not isinstance(geo_id, str):
+            raise ValueError(f"Invalid GSE ID: {geo_id}")
+
+        accession = geo_id.strip().upper()
+        if not accession.startswith("GSE") or not self.validate_identifier(accession):
+            raise ValueError(f"Invalid GSE ID: {geo_id}")
+
+        result = self.search_geo_datasets(
+            f'{accession}[ACCN] AND "rnaseq counts"[Filter]',
+            GEOSearchFilters(max_results=1),
+        )
+        return result.count > 0
+
     def fetch_dataset_metadata(self, geo_id: str) -> Dict[str, Any]:
         """
         Fetch structured metadata for a GEO accession.

--- a/packages/lobster-research/lobster/agents/research/research_agent.py
+++ b/packages/lobster-research/lobster/agents/research/research_agent.py
@@ -1119,6 +1119,8 @@ def research_agent(
                     if entry.dataset_id == identifier
                 ]
 
+                has_ncbi_rnaseq_counts = False
+
                 # Add to queue if requested and not already present
                 if add_to_queue and not queue_entries:
                     try:
@@ -1134,6 +1136,8 @@ def research_agent(
                             f"Successfully added cached dataset {identifier} to download queue "
                             f"with entry_id: {result.queue_entry.entry_id}"
                         )
+
+                        has_ncbi_rnaseq_counts = result.has_ncbi_rnaseq_counts
 
                         # Update queue_entries list for response building
                         queue_entries = [result.queue_entry]
@@ -1158,6 +1162,12 @@ def research_agent(
                     f"**Database**: {metadata.get('database', 'GEO')}",
                     "",
                 ]
+
+                if has_ncbi_rnaseq_counts:
+                    response_parts.append(
+                        "has_ncbi_rnaseq_counts=True: "
+                        "An NCBI-generated raw count source is also available."
+                    )
 
                 # Add queue status if exists
                 if queue_entries:
@@ -1291,6 +1301,12 @@ def research_agent(
                                 if result.url_data:
                                     report += f"- **Files found**: {result.url_data.file_count}\n"
 
+                                if result.has_ncbi_rnaseq_counts:
+                                    report += (
+                                        "has_ncbi_rnaseq_counts=True: "
+                                        "An NCBI-generated raw count source is also available.\n"
+                                    )
+
                                 # Add warnings if validation status has warnings
                                 if (
                                     validation_status
@@ -1421,6 +1437,12 @@ def research_agent(
                 f"**Entry ID**: `{entry.entry_id}`",
                 f"**Status**: {entry.status}",
             ]
+
+            if result.has_ncbi_rnaseq_counts:
+                report_parts.append(
+                    "has_ncbi_rnaseq_counts=True: "
+                    "An NCBI-generated raw count source is also available."
+                )
 
             if strategy:
                 report_parts.extend(
@@ -2257,7 +2279,10 @@ Could not extract content for: {identifier}
         )
         return outcome.response_markdown
 
-    process_publication_entry.metadata = {"categories": ["PREPROCESS"], "provenance": True}
+    process_publication_entry.metadata = {
+        "categories": ["PREPROCESS"],
+        "provenance": True,
+    }
     process_publication_entry.tags = ["PREPROCESS"]
 
     @tool
@@ -2382,7 +2407,10 @@ Could not extract content for: {identifier}
             )
             return result
 
-    process_publication_queue.metadata = {"categories": ["PREPROCESS"], "provenance": True}
+    process_publication_queue.metadata = {
+        "categories": ["PREPROCESS"],
+        "provenance": True,
+    }
     process_publication_queue.tags = ["PREPROCESS"]
 
     # ============================================================
@@ -2394,7 +2422,10 @@ Could not extract content for: {identifier}
     write_to_workspace.metadata = {"categories": ["UTILITY"], "provenance": False}
     write_to_workspace.tags = ["UTILITY"]
     get_content_from_workspace = create_get_content_from_workspace_tool(data_manager)
-    get_content_from_workspace.metadata = {"categories": ["UTILITY"], "provenance": False}
+    get_content_from_workspace.metadata = {
+        "categories": ["UTILITY"],
+        "provenance": False,
+    }
     get_content_from_workspace.tags = ["UTILITY"]
 
     # ============================================================
@@ -2430,7 +2461,9 @@ Could not extract content for: {identifier}
         elif db_lower in providers_map:
             selected = [(db_lower, providers_map[db_lower])]
         else:
-            return f"Unknown database '{database}'. Use: dbaasp, iedb, peptipedia, or all"
+            return (
+                f"Unknown database '{database}'. Use: dbaasp, iedb, peptipedia, or all"
+            )
 
         all_results = []
         for db_name, provider_cls in selected:

--- a/packages/lobster-research/lobster/agents/research/research_agent.py
+++ b/packages/lobster-research/lobster/agents/research/research_agent.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, Optional, Union
 
 from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
+from langgraph.errors import GraphInterrupt
 
 from lobster.agents.research.config import (
     ESSENTIAL_FIELDS,
@@ -188,9 +189,70 @@ def research_agent(
                 QueuePreparationService,
             )
 
+            logger.info(
+                "[GEO preference] initializing research queue preparation service"
+            )
             _queue_preparation_service = QueuePreparationService(data_manager)
+            geo_preparer = _queue_preparation_service.get_preparer_for_database("geo")
+            if geo_preparer is not None:
+                geo_preparer.source_selector = select_geo_source
+            logger.info(
+                "[GEO preference] research queue service ready geo_preparer=%s",
+                type(geo_preparer).__name__,
+            )
             logger.debug("Lazy-loaded QueuePreparationService")
         return _queue_preparation_service
+
+    def select_geo_source(accession):
+        logger.info(
+            "[GEO preference] research selector entered accession=%s interactive=%s",
+            accession,
+            getattr(data_manager, "_interactive", True),
+        )
+        if not getattr(data_manager, "_interactive", True):
+            logger.info(
+                "[GEO preference] question skipped in non-interactive mode accession=%s",
+                accession,
+            )
+            return None
+        from lobster.tools.geo_source_preference import ask_geo_source_preference
+
+        return ask_geo_source_preference(accession)
+
+    def refresh_geo_preference(entry):
+        """Handle legacy/reused entries through the same source selection policy."""
+        logger.info(
+            "[GEO preference] checking reused entry entry_id=%s database=%s available=%s answered=%s",
+            entry.entry_id,
+            entry.database,
+            entry.has_ncbi_rnaseq_counts,
+            entry.source_preference_answered,
+        )
+        if entry.database.lower() != "geo" or entry.source_preference_answered:
+            return entry
+        available = entry.has_ncbi_rnaseq_counts
+        source = entry.selected_source or "author"
+        answered = False
+        if available is None:
+            preparer = get_queue_preparation_service().get_preparer_for_database("geo")
+            fields = preparer.prepare_source(entry.dataset_id)
+            available = fields["has_ncbi_rnaseq_counts"]
+            source = fields["selected_source"]
+            answered = fields["source_preference_answered"]
+        elif available:
+            preference = select_geo_source(entry.dataset_id)
+            if preference is not None:
+                source, answered = preference, True
+        logger.info(
+            "[GEO preference] saving reused entry preference entry_id=%s available=%s source=%s answered=%s",
+            entry.entry_id,
+            available,
+            source,
+            answered,
+        )
+        return data_manager.download_queue.update_geo_preference(
+            entry.entry_id, available, source, answered
+        )
 
     _uniprot_service = None
     _ensembl_service = None
@@ -1119,7 +1181,8 @@ def research_agent(
                     if entry.dataset_id == identifier
                 ]
 
-                has_ncbi_rnaseq_counts = False
+                if add_to_queue:
+                    queue_entries = [refresh_geo_preference(e) for e in queue_entries]
 
                 # Add to queue if requested and not already present
                 if add_to_queue and not queue_entries:
@@ -1130,20 +1193,33 @@ def research_agent(
 
                         service = get_queue_preparation_service()
                         result = service.prepare(identifier)
+                        logger.info(
+                            "[GEO preference] saving queue entry entry_id=%s",
+                            result.queue_entry.entry_id,
+                        )
                         data_manager.download_queue.add_entry(result.queue_entry)
+                        logger.info(
+                            "[GEO preference] queue entry saved entry_id=%s",
+                            result.queue_entry.entry_id,
+                        )
 
                         logger.info(
                             f"Successfully added cached dataset {identifier} to download queue "
                             f"with entry_id: {result.queue_entry.entry_id}"
                         )
 
-                        has_ncbi_rnaseq_counts = result.has_ncbi_rnaseq_counts
-
                         # Update queue_entries list for response building
                         queue_entries = [result.queue_entry]
 
+                    except GraphInterrupt:
+                        logger.info(
+                            "[GEO preference] research preparation paused; propagating interrupt"
+                        )
+
+                        raise
+
                     except Exception as e:
-                        logger.error(
+                        logger.exception(
                             f"Failed to add cached dataset {identifier} to download queue: {e}"
                         )
                         # Continue with response - queue addition is optional
@@ -1162,12 +1238,6 @@ def research_agent(
                     f"**Database**: {metadata.get('database', 'GEO')}",
                     "",
                 ]
-
-                if has_ncbi_rnaseq_counts:
-                    response_parts.append(
-                        "has_ncbi_rnaseq_counts=True: "
-                        "An NCBI-generated raw count source is also available."
-                    )
 
                 # Add queue status if exists
                 if queue_entries:
@@ -1281,7 +1351,17 @@ def research_agent(
                                 )
                                 queue_entry.validation_status = validation_status
 
+                                logger.info(
+                                    "[GEO preference] saving queue entry entry_id=%s",
+                                    queue_entry.entry_id,
+                                )
+
                                 data_manager.download_queue.add_entry(queue_entry)
+
+                                logger.info(
+                                    "[GEO preference] queue entry saved entry_id=%s",
+                                    queue_entry.entry_id,
+                                )
 
                                 entry_id = queue_entry.entry_id
                                 recommended_strategy = queue_entry.recommended_strategy
@@ -1301,12 +1381,6 @@ def research_agent(
                                 if result.url_data:
                                     report += f"- **Files found**: {result.url_data.file_count}\n"
 
-                                if result.has_ncbi_rnaseq_counts:
-                                    report += (
-                                        "has_ncbi_rnaseq_counts=True: "
-                                        "An NCBI-generated raw count source is also available.\n"
-                                    )
-
                                 # Add warnings if validation status has warnings
                                 if (
                                     validation_status
@@ -1324,8 +1398,15 @@ def research_agent(
                                 report += "1. Supervisor can query queue: `get_content_from_workspace(workspace='download_queue')`\n"
                                 report += f"2. Hand off to data_expert with entry_id: `{entry_id}`\n"
 
+                            except GraphInterrupt:
+                                logger.info(
+                                    "[GEO preference] research preparation paused; propagating interrupt"
+                                )
+
+                                raise
+
                             except Exception as e:
-                                logger.error(
+                                logger.exception(
                                     f"Failed to add {identifier} to download queue: {e}"
                                 )
                                 # Return validation result even if queue addition fails
@@ -1350,12 +1431,26 @@ def research_agent(
                         f"For '{identifier}', use `prepare_dataset_download(accession='{identifier}')` instead."
                     )
 
+            except GraphInterrupt:
+                logger.info(
+                    "[GEO preference] research preparation paused; propagating interrupt"
+                )
+
+                raise
+
             except Exception as e:
-                logger.error(f"Error accessing dataset {identifier}: {e}")
+                logger.exception(f"Error accessing dataset {identifier}: {e}")
                 return f"Error accessing dataset {identifier}: {str(e)}"
 
+        except GraphInterrupt:
+            logger.info(
+                "[GEO preference] research preparation paused; propagating interrupt"
+            )
+
+            raise
+
         except Exception as e:
-            logger.error(f"Error in metadata validation: {e}")
+            logger.exception(f"Error in metadata validation: {e}")
             return f"Error validating dataset metadata: {str(e)}"
 
     validate_dataset_metadata.metadata = {"categories": ["QUALITY"], "provenance": True}
@@ -1402,7 +1497,7 @@ def research_agent(
                 if entry.dataset_id == accession
             ]
             if existing:
-                entry = existing[0]
+                entry = refresh_geo_preference(existing[0])
                 return (
                     f"Dataset '{accession}' is already in the download queue.\n"
                     f"- **Entry ID**: `{entry.entry_id}`\n"
@@ -1424,7 +1519,15 @@ def research_agent(
             result = service.prepare(accession, database=database, priority=priority)
 
             # Add to download queue
+            logger.info(
+                "[GEO preference] saving queue entry entry_id=%s",
+                result.queue_entry.entry_id,
+            )
             data_manager.download_queue.add_entry(result.queue_entry)
+            logger.info(
+                "[GEO preference] queue entry saved entry_id=%s",
+                result.queue_entry.entry_id,
+            )
 
             entry = result.queue_entry
             strategy = entry.recommended_strategy
@@ -1437,12 +1540,6 @@ def research_agent(
                 f"**Entry ID**: `{entry.entry_id}`",
                 f"**Status**: {entry.status}",
             ]
-
-            if result.has_ncbi_rnaseq_counts:
-                report_parts.append(
-                    "has_ncbi_rnaseq_counts=True: "
-                    "An NCBI-generated raw count source is also available."
-                )
 
             if strategy:
                 report_parts.extend(
@@ -1478,8 +1575,15 @@ def research_agent(
             )
             return "\n".join(report_parts)
 
+        except GraphInterrupt:
+            logger.info(
+                "[GEO preference] research preparation paused; propagating interrupt"
+            )
+
+            raise
+
         except Exception as e:
-            logger.error(f"Failed to prepare download for {accession}: {e}")
+            logger.exception(f"Failed to prepare download for {accession}: {e}")
             return f"Error preparing download for '{accession}': {str(e)}"
 
     prepare_dataset_download.metadata = {"categories": ["UTILITY"], "provenance": False}

--- a/tests/unit/services/data_access/test_geo_queue_preparer.py
+++ b/tests/unit/services/data_access/test_geo_queue_preparer.py
@@ -24,7 +24,10 @@ def mock_data_manager():
 @pytest.fixture
 def preparer(mock_data_manager):
     """Create a GEOQueuePreparer with mocked dependencies."""
-    return GEOQueuePreparer(data_manager=mock_data_manager)
+    preparer = GEOQueuePreparer(data_manager=mock_data_manager)
+    preparer._geo_provider = MagicMock()
+    preparer._geo_provider.has_ncbi_rnaseq_counts.return_value = False
+    return preparer
 
 
 class TestGDSCanonToGSE:
@@ -153,3 +156,55 @@ class TestGDSCanonToGSE:
 
                 mock_super.assert_called_once_with("GDS5826", 5)
                 assert "original_accession" not in result.queue_entry.metadata
+
+
+@pytest.mark.parametrize("available", [True, False, RuntimeError("NCBI unavailable")])
+def test_ncbi_availability_does_not_change_queue(preparer, available, caplog):
+    from lobster.core.interfaces.queue_preparer import QueuePreparationResult
+    from lobster.core.schemas.download_queue import DownloadQueueEntry
+
+    entry = DownloadQueueEntry(
+        entry_id="test",
+        dataset_id="GSE123",
+        database="geo",
+        matrix_url="https://example.org/author.txt",
+        metadata={"title": "Author data"},
+    )
+    before = entry.model_dump()
+    prepared = QueuePreparationResult(queue_entry=entry)
+    check = preparer._geo_provider.has_ncbi_rnaseq_counts
+    if isinstance(available, Exception):
+        check.side_effect = available
+    else:
+        check.return_value = available
+    with patch(
+        "lobster.core.interfaces.queue_preparer.IQueuePreparer.prepare_queue_entry",
+        return_value=prepared,
+    ) as normal_prepare:
+        result = preparer.prepare_queue_entry("GSE123")
+    normal_prepare.assert_called_once_with("GSE123", 5)
+    check.assert_called_once_with("GSE123")
+    assert result is prepared
+    assert result.has_ncbi_rnaseq_counts is (available is True)
+    assert entry.model_dump() == before
+    if isinstance(available, Exception):
+        assert "Could not check NCBI RNA-seq counts" in caplog.text
+
+
+def test_ncbi_availability_uses_canonical_gse(preparer):
+    with (
+        patch.object(preparer, "_resolve_gds_to_gse", return_value="GSE123"),
+        patch(
+            "lobster.core.interfaces.queue_preparer.IQueuePreparer.prepare_queue_entry"
+        ),
+    ):
+        preparer.prepare_queue_entry("GDS123")
+    preparer._geo_provider.has_ncbi_rnaseq_counts.assert_called_once_with("GSE123")
+
+
+def test_ncbi_availability_skipped_for_non_gse(preparer):
+    with patch(
+        "lobster.core.interfaces.queue_preparer.IQueuePreparer.prepare_queue_entry"
+    ):
+        preparer.prepare_queue_entry("GPL570")
+    preparer._geo_provider.has_ncbi_rnaseq_counts.assert_not_called()

--- a/tests/unit/services/data_access/test_geo_queue_preparer.py
+++ b/tests/unit/services/data_access/test_geo_queue_preparer.py
@@ -159,36 +159,22 @@ class TestGDSCanonToGSE:
 
 
 @pytest.mark.parametrize("available", [True, False, RuntimeError("NCBI unavailable")])
-def test_ncbi_availability_does_not_change_queue(preparer, available, caplog):
-    from lobster.core.interfaces.queue_preparer import QueuePreparationResult
-    from lobster.core.schemas.download_queue import DownloadQueueEntry
-
-    entry = DownloadQueueEntry(
-        entry_id="test",
-        dataset_id="GSE123",
-        database="geo",
-        matrix_url="https://example.org/author.txt",
-        metadata={"title": "Author data"},
-    )
-    before = entry.model_dump()
-    prepared = QueuePreparationResult(queue_entry=entry)
+def test_ncbi_availability_source_fields(preparer, available, caplog):
     check = preparer._geo_provider.has_ncbi_rnaseq_counts
     if isinstance(available, Exception):
         check.side_effect = available
     else:
         check.return_value = available
-    with patch(
-        "lobster.core.interfaces.queue_preparer.IQueuePreparer.prepare_queue_entry",
-        return_value=prepared,
-    ) as normal_prepare:
-        result = preparer.prepare_queue_entry("GSE123")
-    normal_prepare.assert_called_once_with("GSE123", 5)
+    selector = MagicMock(return_value="ncbi")
+    preparer.source_selector = selector
+    fields = preparer.prepare_source("GSE123")
     check.assert_called_once_with("GSE123")
-    assert result is prepared
-    assert result.has_ncbi_rnaseq_counts is (available is True)
-    assert entry.model_dump() == before
-    if isinstance(available, Exception):
-        assert "Could not check NCBI RNA-seq counts" in caplog.text
+    assert fields["has_ncbi_rnaseq_counts"] == (
+        None if isinstance(available, Exception) else available
+    )
+    assert fields["selected_source"] == ("ncbi" if available is True else "author")
+    assert fields["source_preference_answered"] is (available is True)
+    assert selector.call_count == int(available is True)
 
 
 def test_ncbi_availability_uses_canonical_gse(preparer):
@@ -196,15 +182,12 @@ def test_ncbi_availability_uses_canonical_gse(preparer):
         patch.object(preparer, "_resolve_gds_to_gse", return_value="GSE123"),
         patch(
             "lobster.core.interfaces.queue_preparer.IQueuePreparer.prepare_queue_entry"
-        ),
+        ) as base,
     ):
         preparer.prepare_queue_entry("GDS123")
-    preparer._geo_provider.has_ncbi_rnaseq_counts.assert_called_once_with("GSE123")
+    base.assert_called_once_with("GSE123", 5)
 
 
 def test_ncbi_availability_skipped_for_non_gse(preparer):
-    with patch(
-        "lobster.core.interfaces.queue_preparer.IQueuePreparer.prepare_queue_entry"
-    ):
-        preparer.prepare_queue_entry("GPL570")
+    preparer.prepare_source("GPL570")
     preparer._geo_provider.has_ncbi_rnaseq_counts.assert_not_called()

--- a/tests/unit/tools/test_geo_source_preference.py
+++ b/tests/unit/tools/test_geo_source_preference.py
@@ -1,0 +1,154 @@
+from unittest.mock import Mock
+
+import pytest
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command
+from typing_extensions import TypedDict
+
+from lobster.core.download_queue import DownloadQueue
+from lobster.core.schemas.download_queue import DownloadQueueEntry
+from lobster.tools.geo_source_preference import ask_geo_source_preference
+
+
+@pytest.mark.parametrize(
+    "answer,expected",
+    [("Author-uploaded GEO data", "author"), ("NCBI-generated counts", "ncbi")],
+)
+def test_preference_interrupt_and_resume_before_save(tmp_path, answer, expected):
+    queue = DownloadQueue(tmp_path / "queue.jsonl")
+
+    class State(TypedDict):
+        source: str
+
+    def prepare(state):
+        source = ask_geo_source_preference("GSE164073")
+        queue.add_entry(
+            DownloadQueueEntry(
+                entry_id="test",
+                dataset_id="GSE164073",
+                database="geo",
+                has_ncbi_rnaseq_counts=True,
+                selected_source=source,
+                source_preference_answered=True,
+                matrix_url="https://example.org/author.tsv",
+            )
+        )
+        return {"source": source}
+
+    builder = StateGraph(State)
+    builder.add_node("prepare", prepare)
+    builder.add_edge(START, "prepare")
+    builder.add_edge("prepare", END)
+    graph = builder.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "test"}}
+    result = graph.invoke({"source": ""}, config)
+    assert result["__interrupt__"][0].value["component"] == "select"
+    assert queue.list_entries() == []
+    result = graph.invoke(Command(resume={"selected": answer}), config)
+    assert result["source"] == expected
+    entry = queue.get_entry("test")
+    assert entry.selected_source == expected
+    assert entry.matrix_url == "https://example.org/author.tsv"
+    assert len(queue.list_entries()) == 1
+
+
+def test_queue_preference_update_preserves_execution(tmp_path):
+    queue = DownloadQueue(tmp_path / "queue.jsonl")
+    entry = DownloadQueueEntry(
+        entry_id="test", dataset_id="GSE1", database="geo", matrix_url="author"
+    )
+    queue.add_entry(entry)
+    queue.update_geo_preference("test", True, "ncbi", True)
+    updated = queue.get_entry("test")
+    assert updated.selected_source == "ncbi"
+    assert updated.matrix_url == entry.matrix_url
+    assert updated.status == entry.status
+
+
+def test_non_geo_defaults_and_update_rejection(tmp_path):
+    queue = DownloadQueue(tmp_path / "queue.jsonl")
+    entry = DownloadQueueEntry(entry_id="test", dataset_id="PXD1", database="pride")
+    queue.add_entry(entry)
+    assert entry.selected_source is None
+    with pytest.raises(ValueError, match="only to GEO"):
+        queue.update_geo_preference("test", True, "ncbi", True)
+    assert queue.get_entry("test").selected_source is None
+
+
+def test_handoff_appends_persisted_geo_preference(tmp_path):
+    import asyncio
+    from unittest.mock import AsyncMock
+    from langchain_core.messages import AIMessage
+    from lobster.agents.graph import _invoke_and_store
+
+    queue = DownloadQueue(tmp_path / "queue.jsonl")
+    queue.add_entry(
+        DownloadQueueEntry(
+            entry_id="geo",
+            dataset_id="GSE164073",
+            database="geo",
+            has_ncbi_rnaseq_counts=True,
+            selected_source="ncbi",
+            source_preference_answered=True,
+        )
+    )
+    agent = Mock()
+    agent.ainvoke = AsyncMock(
+        return_value={
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "prepare_dataset_download",
+                            "args": {"accession": "GSE164073"},
+                            "id": "call1",
+                        }
+                    ],
+                ),
+                AIMessage(content="Prepared your dataset."),
+            ]
+        }
+    )
+    dm = Mock(download_queue=queue)
+    result = asyncio.run(
+        _invoke_and_store(agent, "research_agent", "prepare", None, dm)
+    )
+    assert "has_ncbi_rnaseq_counts=True" in result
+    assert "selected_source=ncbi" in result
+    other = asyncio.run(
+        _invoke_and_store(agent, "data_expert_agent", "prepare", None, dm)
+    )
+    assert other == "Prepared your dataset."
+
+
+def test_source_choice_happens_after_metadata_before_entry():
+    from lobster.services.data_access.geo_queue_preparer import GEOQueuePreparer
+    from lobster.core.schemas.download_queue import StrategyConfig
+
+    preparer = GEOQueuePreparer(Mock())
+    events = []
+    preparer.fetch_metadata = Mock(
+        side_effect=lambda accession: (events.append("metadata") or {}, None)
+    )
+    preparer._geo_provider = Mock()
+    preparer._geo_provider.has_ncbi_rnaseq_counts.side_effect = lambda accession: (
+        events.append("availability") or True
+    )
+    preparer.source_selector = lambda accession: events.append("question") or "ncbi"
+    preparer.extract_download_urls = Mock(
+        return_value=Mock(to_queue_entry_fields=lambda: {}, file_count=0)
+    )
+    preparer.recommend_strategy = Mock(
+        return_value=StrategyConfig(
+            strategy_name="AUTO",
+            concatenation_strategy="auto",
+            confidence=0.5,
+            rationale="test",
+        )
+    )
+    result = preparer.prepare_queue_entry("GSE164073")
+    assert events == ["metadata", "availability", "question"]
+    assert result.queue_entry.selected_source == "ncbi"
+    assert result.queue_entry.has_ncbi_rnaseq_counts is True


### PR DESCRIPTION
I'm working on issue #22 and wanted to get some feedback on my approach. After looking through the NCBI documentation, it seems possible to determine whether a GEO Series has an NCBI-generated raw count matrix available using the ESearch endpoint.
I added a helper that takes a GEO ID and returns a boolean based on whether NCBI-generated raw counts are available. I then added that information into the existing download flow and added a prompt at the supervisor confirmation step so the user can choose between the author uploaded source and the NCBI-generated raw counts.
For now, the choice is only shown to the user and is not acted on. I wanted to check whether this approach fits the project conventions, and whether the way I structured the code looks appropriate for the current architecture, before I implement the actual download and GeneID mapping.