### PR TITLE
Fix classic chat ask user

### DIFF
--- a/lobster/cli_internal/classic_interaction.py
+++ b/lobster/cli_internal/classic_interaction.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 
-def handle_interrupt_classic(interrupt_data: Dict[str, Any]) -> Dict[str, Any]:
+def handle_interrupt_classic(interrupt_data: Any) -> Dict[str, Any]:
     """Render an interrupt as a terminal prompt and collect the response.
 
     Args:
@@ -19,13 +19,30 @@ def handle_interrupt_classic(interrupt_data: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         User's response as a dict matching the component's output_schema.
     """
+    if not isinstance(interrupt_data, dict):
+        question = interrupt_data if isinstance(interrupt_data, str) else ""
+        return _handle_text_input(question or "Please provide input", {})
+
     component = interrupt_data.get("component", "text_input")
     fallback = interrupt_data.get("fallback_prompt", "Please provide input:")
     data = interrupt_data.get("data", {})
+    if not isinstance(fallback, str) or not fallback.strip():
+        fallback = "Please provide input"
+    if not isinstance(data, dict):
+        return _handle_text_input(fallback, {})
+    if not isinstance(data.get("question"), str) or not data["question"].strip():
+        data = {**data, "question": fallback}
 
     if component == "confirm":
         return _handle_confirm(fallback, data)
     elif component == "select":
+        options = data.get("options")
+        if not (
+            isinstance(options, list)
+            and options
+            and all(isinstance(option, str) and option.strip() for option in options)
+        ):
+            return _handle_text_input(fallback, data)
         return _handle_select(fallback, data)
     elif component == "threshold_slider":
         return _handle_threshold(fallback, data)

--- a/lobster/cli_internal/commands/heavy/chat_commands.py
+++ b/lobster/cli_internal/commands/heavy/chat_commands.py
@@ -22,6 +22,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
+from lobster.cli_internal.classic_interaction import handle_interrupt_classic
 from lobster.cli_internal.commands.heavy.animations import (
     display_goodbye,
     display_welcome,
@@ -704,6 +705,15 @@ def _show_workspace_prompt(client):
         console.print()
 
 
+def _query_classic(client, user_input: str) -> Dict[str, Any]:
+    """Run a query and resume after any supervisor questions."""
+    result = client.query(user_input, stream=False)
+    while result.get("interrupts"):
+        response = handle_interrupt_classic(result["interrupts"][0]["data"])
+        result = next(client.resume_from_interrupt(response, stream=False))
+    return result
+
+
 def _display_streaming_response(
     client,
     user_input: str,
@@ -727,48 +737,66 @@ def _display_streaming_response(
         with Live(
             initial_status, console=console, refresh_per_second=10, transient=True
         ) as live:
-            for event in client.query(user_input, stream=True):
-                event_type = event.get("type")
+            stream_source = client.query(user_input, stream=True)
+            while True:
+                interrupt_event = None
+                for event in stream_source:
+                    event_type = event.get("type")
 
-                if event_type == "content_delta":
-                    accumulated_text += event.get("delta", "")
-                    # Build display with agent indicator + text
-                    display = Text()
-                    if last_agent:
-                        agent_display = last_agent.replace("_", " ").title()
-                        display.append(f"◀ {agent_display}\n", style="dim")
-                    display.append(accumulated_text)
-                    live.update(display)
+                    if event_type == "interrupt":
+                        interrupt_event = event
+                        break
 
-                elif event_type == "agent_change":
-                    agent = event.get("agent", "")
-                    if event.get("status") == "working":
-                        last_agent = agent
-                        # Update status indicator before first content arrives
-                        if not accumulated_text:
-                            agent_display = agent.replace("_", " ").title()
-                            status = Text()
-                            status.append(f"◀ {agent_display}", style="dim")
-                            status.append("  Working…", style="dim italic")
-                            live.update(status)
+                    elif event_type == "content_delta":
+                        accumulated_text += event.get("delta", "")
+                        # Build display with agent indicator + text
+                        display = Text()
+                        if last_agent:
+                            agent_display = last_agent.replace("_", " ").title()
+                            display.append(f"◀ {agent_display}\n", style="dim")
+                        display.append(accumulated_text)
+                        live.update(display)
 
-                elif event_type == "complete":
-                    # Use accumulated text, or fallback to response from event
-                    response_text = accumulated_text or event.get("response", "")
-                    final_result = {
-                        "success": True,
-                        "response": response_text,
-                        "last_agent": event.get("last_agent"),
-                        "token_usage": event.get("token_usage"),
-                        "plots": [],  # Plots handled separately
-                    }
+                    elif event_type == "agent_change":
+                        agent = event.get("agent", "")
+                        if event.get("status") == "working":
+                            last_agent = agent
+                            # Update status indicator before first content arrives
+                            if not accumulated_text:
+                                agent_display = agent.replace("_", " ").title()
+                                status = Text()
+                                status.append(f"◀ {agent_display}", style="dim")
+                                status.append("  Working…", style="dim italic")
+                                live.update(status)
 
-                elif event_type == "error":
-                    final_result = {
-                        "success": False,
-                        "error": event.get("error", "Unknown error"),
-                    }
+                    elif event_type == "complete":
+                        # Use accumulated text, or fallback to response from event
+                        response_text = accumulated_text or event.get("response", "")
+                        final_result = {
+                            "success": True,
+                            "response": response_text,
+                            "last_agent": event.get("last_agent"),
+                            "token_usage": event.get("token_usage"),
+                            "plots": [],  # Plots handled separately
+                        }
+
+                    elif event_type == "error":
+                        final_result = {
+                            "success": False,
+                            "error": event.get("error", "Unknown error"),
+                        }
+                        break
+
+                if interrupt_event is None:
                     break
+
+                live.stop()
+                response = handle_interrupt_classic(interrupt_event["data"])
+                accumulated_text = ""
+                last_agent = None
+                live.update(initial_status)
+                live.start()
+                stream_source = client.resume_from_interrupt(response, stream=True)
 
         return final_result
 
@@ -1051,7 +1079,7 @@ def chat_impl(
                 if should_show_progress(client):
                     console.print("[dim]...[/dim]", end="", flush=True)
 
-                result = client.query(user_input, stream=False)
+                result = _query_classic(client, user_input)
 
                 if should_show_progress(client):
                     console.print("\r   \r", end="", flush=True)

--- a/lobster/cli_internal/commands/heavy/chat_commands.py
+++ b/lobster/cli_internal/commands/heavy/chat_commands.py
@@ -705,11 +705,21 @@ def _show_workspace_prompt(client):
         console.print()
 
 
-def _query_classic(client, user_input: str) -> Dict[str, Any]:
+def _collect_classic_answers(interrupts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Address each answer to its LangGraph interrupt, including parallel pauses."""
+    if any(not event.get("interrupt_id") for event in interrupts):
+        raise ValueError("Cannot resume a question without its interrupt ID")
+    return {
+        event["interrupt_id"]: handle_interrupt_classic(event.get("data"))
+        for event in interrupts
+    }
+
+
+def _query_classic(client, user_input: str) -> dict[str, Any]:
     """Run a query and resume after any supervisor questions."""
     result = client.query(user_input, stream=False)
     while result.get("interrupts"):
-        response = handle_interrupt_classic(result["interrupts"][0]["data"])
+        response = _collect_classic_answers(result["interrupts"])
         result = next(client.resume_from_interrupt(response, stream=False))
     return result
 
@@ -739,13 +749,12 @@ def _display_streaming_response(
         ) as live:
             stream_source = client.query(user_input, stream=True)
             while True:
-                interrupt_event = None
+                interrupts = []
                 for event in stream_source:
                     event_type = event.get("type")
 
                     if event_type == "interrupt":
-                        interrupt_event = event
-                        break
+                        interrupts.append(event)
 
                     elif event_type == "content_delta":
                         accumulated_text += event.get("delta", "")
@@ -787,11 +796,13 @@ def _display_streaming_response(
                         }
                         break
 
-                if interrupt_event is None:
+                if not interrupts:
                     break
 
                 live.stop()
-                response = handle_interrupt_classic(interrupt_event["data"])
+                if accumulated_text:
+                    console.print(Markdown(accumulated_text))
+                response = _collect_classic_answers(interrupts)
                 accumulated_text = ""
                 last_agent = None
                 live.update(initial_status)

--- a/lobster/core/client.py
+++ b/lobster/core/client.py
@@ -452,6 +452,7 @@ class AgentClient(BaseClient):
             seen_content_hashes: set = set()
             seen_compaction_signatures: set[tuple[str, Any, Any, Any]] = set()
             was_cancelled = False
+            pending_interrupts = {}
 
             # Active speaker tracks which agent currently owns the
             # narrative.  Updated by handoff tool calls (start) and
@@ -623,14 +624,13 @@ class AgentClient(BaseClient):
                                 }
                                 return
                             for interrupt_obj in chunk["__interrupt__"]:
-                                yield {
-                                    "type": "interrupt",
-                                    "data": getattr(
-                                        interrupt_obj, "value", interrupt_obj
-                                    ),
-                                    "interrupt_id": getattr(interrupt_obj, "id", None),
-                                }
-                            return  # Stream ends at interrupt checkpoint.
+                                interrupt_id = getattr(interrupt_obj, "id", None)
+                                pending_interrupts[
+                                    interrupt_id or id(interrupt_obj)
+                                ] = interrupt_obj
+                            # Drain the graph so parallel tasks finish checkpointing.
+                            # Nested and parent updates can report the same interrupt.
+                            continue
 
                         for node_name, node_update in chunk.items():
                             if isinstance(node_update, dict):
@@ -673,6 +673,15 @@ class AgentClient(BaseClient):
             if was_cancelled:
                 if pre_query_msg_count is not None:
                     self._rollback_cancelled_query(config, pre_query_msg_count)
+                return
+
+            if pending_interrupts:
+                for intr in pending_interrupts.values():
+                    yield {
+                        "type": "interrupt",
+                        "data": getattr(intr, "value", intr),
+                        "interrupt_id": getattr(intr, "id", None),
+                    }
                 return
 
             # Check for lingering HITL interrupts that didn't appear in the

--- a/lobster/core/client.py
+++ b/lobster/core/client.py
@@ -326,6 +326,19 @@ class AgentClient(BaseClient):
                         "session_id": self.session_id,
                     }
 
+                if event.get("__interrupt__"):
+                    return {
+                        "success": False,
+                        "interrupts": [
+                            {
+                                "data": getattr(intr, "value", intr),
+                                "interrupt_id": getattr(intr, "id", None),
+                            }
+                            for intr in event["__interrupt__"]
+                        ],
+                        "session_id": self.session_id,
+                    }
+
                 # Track which agent is responding
                 if event:
                     for node_name in event.keys():

--- a/tests/unit/cli/test_chat_commands.py
+++ b/tests/unit/cli/test_chat_commands.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from lobster.cli_internal.commands.heavy import chat_commands
+
+
+class _QueryClient:
+    def __init__(self):
+        self.answers = []
+
+    def query(self, text, stream=False):
+        question = {"data": {"component": "text_input", "fallback_prompt": "Name?"}}
+        if stream:
+            return iter(
+                [
+                    {"type": "content_delta", "delta": "Before question"},
+                    {"type": "interrupt", **question},
+                ]
+            )
+        return {"success": False, "interrupts": [question]}
+
+    def resume_from_interrupt(self, response, stream=True):
+        self.answers.append(response)
+        yield {"type": "complete", "success": True, "response": "Finished"}
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_classic_chat_prompts_and_resumes(stream):
+    client = _QueryClient()
+    console = Console(record=True)
+    with patch("builtins.input", return_value="Alice") as prompt:
+        if stream:
+            result = chat_commands._display_streaming_response(client, "hello", console)
+        else:
+            result = chat_commands._query_classic(client, "hello")
+
+    prompt.assert_called_once_with("\nName?: ")
+    assert client.answers == [{"answer": "Alice"}]
+    assert result["success"] is True
+    assert result["response"] == "Finished"

--- a/tests/unit/cli/test_chat_commands.py
+++ b/tests/unit/cli/test_chat_commands.py
@@ -1,9 +1,14 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
+from langchain_core.messages import AIMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.types import Command, interrupt
 from rich.console import Console
 
 from lobster.cli_internal.commands.heavy import chat_commands
+from lobster.core.client import AgentClient
 
 
 class _QueryClient:
@@ -11,7 +16,10 @@ class _QueryClient:
         self.answers = []
 
     def query(self, text, stream=False):
-        question = {"data": {"component": "text_input", "fallback_prompt": "Name?"}}
+        question = {
+            "interrupt_id": "question-1",
+            "data": {"component": "text_input", "fallback_prompt": "Name?"},
+        }
         if stream:
             return iter(
                 [
@@ -37,6 +45,109 @@ def test_classic_chat_prompts_and_resumes(stream):
             result = chat_commands._query_classic(client, "hello")
 
     prompt.assert_called_once_with("\nName?: ")
-    assert client.answers == [{"answer": "Alice"}]
+    assert client.answers == [{"question-1": {"answer": "Alice"}}]
     assert result["success"] is True
     assert result["response"] == "Finished"
+
+    if stream:
+        assert "Before question" in console.export_text()
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_classic_chat_cancellation_does_not_resume(stream):
+    client = _QueryClient()
+    with patch("builtins.input", side_effect=KeyboardInterrupt):
+        if stream:
+            result = chat_commands._display_streaming_response(
+                client, "hello", Console()
+            )
+            assert result["error"] == "Interrupted by user"
+        else:
+            with pytest.raises(KeyboardInterrupt):
+                chat_commands._query_classic(client, "hello")
+    assert client.answers == []
+
+
+@pytest.mark.parametrize("stream", [True, False])
+@pytest.mark.parametrize("questions", ["none", "one", "sequential", "parallel"])
+def test_classic_chat_with_checkpointed_graph(tmp_path, stream, questions):
+    """Exercise real client resume Commands and checkpoint IDs without an LLM."""
+    answers = []
+
+    def ask(question):
+        answer = interrupt({"component": "text_input", "fallback_prompt": question})
+        answers.append(answer)
+        return {}
+
+    builder = StateGraph(MessagesState)
+    builder.add_node(
+        "supervisor", lambda state: {"messages": [AIMessage(content="Finished")]}
+    )
+    if questions == "none":
+        builder.add_edge(START, "supervisor")
+    else:
+        builder.add_node("first", lambda state: ask("First?"))
+        builder.add_edge(START, "first")
+        if questions in ("sequential", "parallel"):
+            builder.add_node("second", lambda state: ask("Second?"))
+            if questions == "parallel":
+                builder.add_edge(START, "second")
+                builder.add_edge(["first", "second"], "supervisor")
+            else:
+                builder.add_edge("first", "second")
+                builder.add_edge("second", "supervisor")
+        else:
+            builder.add_edge("first", "supervisor")
+    builder.add_edge("supervisor", END)
+    # Production also wraps the supervisor graph in an outer StateGraph.
+    outer = StateGraph(MessagesState)
+    outer.add_node("supervisor", builder.compile())
+    outer.add_edge(START, "supervisor")
+    outer.add_edge("supervisor", END)
+    graph = outer.compile(checkpointer=InMemorySaver())
+    data_manager = Mock(profile_timings_enabled=False)
+    data_manager.has_data.return_value = False
+    with patch(
+        "lobster.core.client.create_bioinformatics_graph", return_value=(graph, Mock())
+    ):
+        client = AgentClient(data_manager=data_manager, workspace_path=tmp_path)
+    client._save_session_json = Mock(return_value=None)
+    graph.stream = Mock(wraps=graph.stream)
+    expected_responses = {}
+
+    def answer_question(prompt):
+        state = graph.get_state({"configurable": {"thread_id": client.session_id}})
+        expected_responses.update(
+            (intr.id, {"answer": intr.value["fallback_prompt"]})
+            for task in state.tasks
+            for intr in task.interrupts
+        )
+        return prompt.strip().removesuffix(":")
+
+    with patch("builtins.input", side_effect=answer_question) as prompt:
+        if stream:
+            result = chat_commands._display_streaming_response(
+                client, "hello", Console()
+            )
+        else:
+            result = chat_commands._query_classic(client, "hello")
+
+    count = {"none": 0, "one": 1, "sequential": 2, "parallel": 2}[questions]
+    assert result["success"] is True, result
+    assert result["response"] == "Finished"
+    assert prompt.call_count == count
+    assert (
+        sorted(answer["answer"] for answer in answers) == ["First?", "Second?"][:count]
+    )
+    commands = [
+        call.args[0] if call.args else call.kwargs["input"]
+        for call in graph.stream.call_args_list
+    ]
+    resumes = [command.resume for command in commands if isinstance(command, Command)]
+    assert {
+        key: value for response in resumes for key, value in response.items()
+    } == expected_responses
+    if questions == "parallel":
+        assert len(resumes) == 1
+        assert len(resumes[0]) == 2
+    assert not graph.get_state({"configurable": {"thread_id": client.session_id}}).next

--- a/tests/unit/cli/test_classic_interaction.py
+++ b/tests/unit/cli/test_classic_interaction.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from lobster.cli_internal.classic_interaction import handle_interrupt_classic
 
 
@@ -133,3 +135,27 @@ def test_cell_type_selector():
     with patch("builtins.input", side_effect=inputs):
         result = handle_interrupt_classic(data)
     assert result == {"assignments": {"0": "T cells", "1": "B cells"}}
+
+
+@pytest.mark.parametrize("options", [None, [], "A", {}, [None], [1], [""], ["A", " "]])
+def test_invalid_select_options_fall_back_to_text(options, capsys):
+    data = {"component": "select", "data": {"question": "Choose?", "options": options}}
+    with patch("builtins.input", return_value="custom answer") as prompt:
+        assert handle_interrupt_classic(data) == {"answer": "custom answer"}
+    prompt.assert_called_once_with("\nChoose?: ")
+    assert "between" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("data", [{}, {"options": []}, None, []])
+def test_missing_or_malformed_select_data_falls_back_to_text(data):
+    payload = {"component": "select", "fallback_prompt": "Choose?", "data": data}
+    with patch("builtins.input", return_value="answer") as prompt:
+        assert handle_interrupt_classic(payload) == {"answer": "answer"}
+    prompt.assert_called_once_with("\nChoose?: ")
+
+
+@pytest.mark.parametrize("payload", [None, [], "Choose?"])
+def test_malformed_payload_falls_back_to_text(payload):
+    with patch("builtins.input", return_value="answer") as prompt:
+        assert handle_interrupt_classic(payload) == {"answer": "answer"}
+    prompt.assert_called_once()

--- a/tests/unit/core/test_client_interrupt.py
+++ b/tests/unit/core/test_client_interrupt.py
@@ -217,3 +217,26 @@ def test_resume_from_interrupt_streams_resumed_events(tmp_path):
     from langgraph.types import Command
 
     assert isinstance(call_args[0][0], Command)
+
+
+def test_nonstreaming_interrupt_returns_pause_without_saving_response(tmp_path):
+    payload = {"component": "text_input", "data": {"question": "Name?"}}
+    client = _make_client_with_stream_events(
+        tmp_path, [{"__interrupt__": [SimpleNamespace(value=payload, id="question-1")]}]
+    )
+    client._save_session_json = Mock()
+    result = client.query("hello", stream=False)
+    assert result["interrupts"] == [{"data": payload, "interrupt_id": "question-1"}]
+    assert len(client.messages) == 1
+    client._save_session_json.assert_not_called()
+
+
+def test_noninteractive_interrupt_still_returns_actionable_error(tmp_path):
+    client = _make_client_with_stream_events(
+        tmp_path, [{"__interrupt__": [SimpleNamespace(value={}, id="question-1")]}]
+    )
+    client.interactive = False
+    result = client.query("hello", stream=False)
+    assert result["success"] is False
+    assert "non-interactive" in result["error"]
+    assert "interrupts" not in result


### PR DESCRIPTION
## Description

Fixes “Unknown Error” in classic chat (Issue #35) when the supervisor calls `ask_user`.

Classic chat now displays the question, collects the user’s answer, and resumes execution using the existing interrupt-handling pattern.

Supports both streaming and non-streaming chat and reuses the existing question renderer.

## Type of Change

- [x] Bug fix
- [ ] New feature (agent, service, tool)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Breaking change

## Testing

- [x] Tests added/updated
- [ ] Contract tests pass — N/A; no agents or tools changed
- [x] Manual testing performed

I expanded the tests beyond the original error to make sure questions work in both streaming and non-streaming chat. The tests also cover consecutive and simultaneous questions, malformed options, cancellation, and regular messages without questions.
The interrupt tests use real checkpointed LangGraph graphs to confirm that each answer is matched to the right question and that execution resumes correctly.

All 186 targeted tests passed.

## Checklist

- [x] Code follows project style (PEP 8, type hints)
- [ ] AQUADIF metadata assigned to new tools — N/A
- [ ] Provenance (`ir=`) passed in `log_tool_usage` for new tools — N/A
- [x] Self-review completed